### PR TITLE
Reduce mobile photo heights to prevent overlap with buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,7 +657,8 @@
 
             .photo-grid-item {
                 flex: 0 0 72vw;
-                aspect-ratio: 4 / 5;
+                aspect-ratio: 3 / 2;
+                max-height: 45vh;
                 scroll-snap-align: start;
                 border-radius: 8px;
             }

--- a/photo.html
+++ b/photo.html
@@ -518,7 +518,7 @@
             }
 
             .collection-card {
-                aspect-ratio: 16 / 7;
+                aspect-ratio: 5 / 2;
             }
 
             .photo-grid {


### PR DESCRIPTION
### Motivation
- Horizontally scrolling images on the homepage were tall enough on small screens that they overlapped/cut off UI (buttons and captions). 
- Collection cards on the photography page were still too tall on mobile, causing awkward layout and visual overlap.

### Description
- In `index.html` mobile media query, changed `.photo-grid-item` `aspect-ratio` from `4 / 5` to `3 / 2` and added `max-height: 45vh` to limit the scroller card height. 
- In `photo.html` mobile media query, reduced the collection card height by changing `.collection-card` `aspect-ratio` from `16 / 7` to `5 / 2`.
- These are purely CSS adjustments scoped to `@media (max-width: 768px)` to preserve desktop layout.

### Testing
- Started a static server with `python -m http.server 8000` and verified pages render. 
- Ran a Playwright script with a mobile viewport (`390x844`) that visited `http://127.0.0.1:8000/index.html` and `http://127.0.0.1:8000/photo.html` and captured screenshots `artifacts/index-mobile.png` and `artifacts/photo-mobile.png`, which were produced successfully. 
- No unit tests were applicable since this is a static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aca874cb883309792382847b8d43c)