### PR TITLE
Add SVG favicon across site pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>404 | Alec (Jude) Wilson</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@100..900&display=swap" rel="stylesheet">

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About | Judes Club</title>
-    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/assets/3.css">
     <link rel="stylesheet" href="https://use.typekit.net/rup4qgs.css">
 </head>

--- a/apps/bookly/index.html
+++ b/apps/bookly/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Bookly: AI Book Tracker</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <meta
       name="description"
       content="Simple, focused apps crafted by an indie developer."

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2fe6a8" />
+      <stop offset="1" stop-color="#0a3d2c" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#111111" />
+  <circle cx="32" cy="32" r="22" fill="url(#g)" />
+  <text
+    x="32"
+    y="40"
+    text-anchor="middle"
+    font-family="Inter, Arial, sans-serif"
+    font-size="28"
+    font-weight="600"
+    fill="#ffffff"
+  >
+    J
+  </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#111111">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <title>Alec (Jude) Wilson</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
     <meta name="description" content="Developer and photographer based in New York. I build software and take photos.">
     <meta property="og:title" content="Alec (Jude) Wilson">
     <meta property="og:description" content="Developer and photographer based in New York. I build software and take photos.">

--- a/love.html
+++ b/love.html
@@ -5,6 +5,7 @@
     <meta charset='UTF-8'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0'>
     <title>Document</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
 </head>
 
 <body>

--- a/old.html
+++ b/old.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Judes Club</title>
-        <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
+        <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
         <link rel="stylesheet" href="https://use.typekit.net/mln8zle.css" />
         <style>
             * {

--- a/photo.html
+++ b/photo.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Photography | Alec (Jude) Wilson</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
     <meta name="description" content="Photography by Alec (Jude) Wilson. Film and digital across Latin America, the US, Europe, Africa, and beyond.">
     <meta property="og:title" content="Photography | Alec (Jude) Wilson">
     <meta property="og:description" content="Photography by Alec (Jude) Wilson. Film and digital across Latin America, the US, Europe, Africa, and beyond.">

--- a/think-app.html
+++ b/think-app.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Think. App</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
### Motivation
- Provide a scalable, modern favicon so browsers and apps show a consistent site icon across pages and sub-apps.

### Description
- Add `assets/favicon.svg`, a 64x64 SVG asset with a rounded dark background, a green gradient circle, and a centered "J" glyph.
- Link the new favicon by adding `<link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">` to `index.html`, `about.html`, `photo.html`, `love.html`, `404.html`, `old.html`, `think-app.html`, and `apps/bookly/index.html`.
- Replace legacy `.ico` references with the new SVG where present.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697acbe255308330b3d5d678244b92d9)