### PR TITLE
Add Projects overview & template; constrain photo scroller sizing

### DIFF
--- a/404.html
+++ b/404.html
@@ -196,6 +196,7 @@
             <a href="/" class="logo">Alec (Jude) Wilson</a>
             <ul class="nav-menu">
                 <li><a href="/#apps">Apps</a></li>
+                <li><a href="/projects">Projects</a></li>
                 <li><a href="/photo">Photography</a></li>
                 <li><a href="/#contact">Contact</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -534,14 +534,15 @@
         /* Photo grid */
         .photo-grid {
             display: grid;
-            grid-template-columns: repeat(4, 1fr);
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
             gap: 0.75rem;
             margin-top: 2.5rem;
             margin-bottom: 1rem;
         }
 
         .photo-grid-item {
-            aspect-ratio: 1;
+            aspect-ratio: 4 / 3;
+            height: clamp(160px, 18vw, 220px);
             background: rgba(255, 255, 255, 0.08);
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
@@ -660,6 +661,7 @@
                 flex: 0 0 72vw;
                 aspect-ratio: 3 / 2;
                 max-height: 45vh;
+                height: auto;
                 scroll-snap-align: start;
                 border-radius: 8px;
             }
@@ -703,6 +705,7 @@
             <div class="logo">Alec (Jude) Wilson</div>
             <ul class="nav-menu">
                 <li><a href="#apps">Apps</a></li>
+                <li><a href="/projects">Projects</a></li>
                 <li><a href="/photo">Photography</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>

--- a/photo.html
+++ b/photo.html
@@ -542,6 +542,7 @@
         <div class="nav-container">
             <a href="/" class="logo">Alec (Jude) Wilson</a>
             <ul class="nav-menu">
+                <li><a href="/projects">Projects</a></li>
                 <li><a href="https://unsplash.com/@alechash" target="_blank">Unsplash</a></li>
                 <li><a href="https://instagram.com/wil.tography" target="_blank">Instagram</a></li>
                 <li><a href="https://glass.photo/wilude" target="_blank">Glass</a></li>

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,0 +1,497 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Projects | Alec (Jude) Wilson</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+    <meta name="description" content="Projects by Alec (Jude) Wilson. Product experiments, prototypes, and live apps.">
+    <meta property="og:title" content="Projects | Alec (Jude) Wilson">
+    <meta property="og:description" content="Projects by Alec (Jude) Wilson. Product experiments, prototypes, and live apps.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="/bg.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@100..900&display=swap" rel="stylesheet">
+    <style>
+        html {
+            scroll-behavior: smooth;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Instrument Serif', serif;
+            font-style: italic;
+            min-height: 100vh;
+            background: #111;
+            color: white;
+        }
+
+        .navbar {
+            position: fixed;
+            top: 0;
+            right: 0;
+            left: 0;
+            z-index: 1000;
+            padding: 1.5rem 2rem;
+        }
+
+        .nav-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: 400;
+            letter-spacing: 0.5px;
+            color: white;
+            font-family: 'Instrument Serif', serif;
+            font-style: italic;
+            padding: 0.5rem 1.5rem;
+            background: radial-gradient(ellipse 150% 100% at center, rgba(10, 61, 44, 0.4) 0%, transparent 100%);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            text-decoration: none;
+        }
+
+        .nav-menu {
+            display: flex;
+            list-style: none;
+            gap: 0.5rem;
+        }
+
+        .nav-menu a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 300;
+            letter-spacing: 0.5px;
+            transition: opacity 0.3s;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            padding: 0.5rem 0.5rem;
+            display: block;
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            transform: scaleX(0.8);
+            background: radial-gradient(ellipse 150% 100% at center, rgba(10, 61, 44, 0.4) 0%, transparent 100%);
+        }
+
+        .nav-menu a:hover {
+            opacity: 0.6;
+        }
+
+        @media (max-width: 500px) {
+            .navbar {
+                padding: 1.5rem 1.5rem;
+            }
+
+            .nav-container {
+                align-items: flex-start;
+            }
+
+            .nav-menu {
+                flex-direction: column;
+                gap: 0.5rem;
+                text-align: right;
+            }
+
+            .nav-menu a {
+                font-size: 0.85rem;
+            }
+        }
+
+        .page-content {
+            padding: 8rem 2rem 4rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .page-content h1 {
+            font-size: 3rem;
+            font-weight: 400;
+            margin-bottom: 0.5rem;
+            letter-spacing: 0.5px;
+            font-style: normal;
+        }
+
+        .page-subtitle {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 1rem;
+            font-weight: 300;
+            opacity: 0.5;
+            margin-bottom: 3rem;
+            line-height: 1.6;
+            max-width: 700px;
+        }
+
+        .page-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-bottom: 3rem;
+        }
+
+        .page-links a {
+            display: inline-block;
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            letter-spacing: 0.5px;
+            padding: 0.6rem 1.25rem;
+            background: rgba(255, 255, 255, 0.06);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            transition: background 0.3s, border-color 0.3s;
+        }
+
+        .page-links a:hover {
+            background: rgba(255, 255, 255, 0.14);
+            border-color: rgba(255, 255, 255, 0.4);
+        }
+
+        .page-links a.active {
+            border-color: rgba(255, 255, 255, 0.5);
+            background: rgba(255, 255, 255, 0.12);
+        }
+
+        .section-heading {
+            font-size: 1.6rem;
+            font-weight: 400;
+            font-style: normal;
+            margin-bottom: 1.5rem;
+            letter-spacing: 0.3px;
+        }
+
+        .projects-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 1.25rem;
+            margin-bottom: 4rem;
+        }
+
+        .project-card {
+            position: relative;
+            display: block;
+            text-decoration: none;
+            color: white;
+            overflow: hidden;
+            aspect-ratio: 16 / 10;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            transition: border-color 0.3s, transform 0.3s;
+        }
+
+        .project-card:hover {
+            border-color: rgba(255, 255, 255, 0.25);
+            transform: translateY(-2px);
+        }
+
+        .project-card img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            transition: transform 0.5s ease;
+        }
+
+        .project-card:hover img {
+            transform: scale(1.03);
+        }
+
+        .project-card .project-title {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            padding: 1.25rem;
+            font-family: 'Instrument Serif', serif;
+            font-size: 1.3rem;
+            font-weight: 400;
+            font-style: normal;
+            background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 100%);
+            text-shadow: 0 1px 10px rgba(0, 0, 0, 0.6);
+        }
+
+        .project-card .project-meta {
+            position: absolute;
+            top: 1rem;
+            left: 1rem;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.75rem;
+            letter-spacing: 0.6px;
+            text-transform: uppercase;
+            padding: 0.35rem 0.7rem;
+            background: rgba(17, 17, 17, 0.6);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            backdrop-filter: blur(14px);
+        }
+
+        .project-notes {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 1rem;
+            margin-bottom: 3.5rem;
+        }
+
+        .note-card {
+            padding: 1.5rem;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.04);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+
+        .note-card h3 {
+            font-size: 1.1rem;
+            font-weight: 400;
+            font-style: normal;
+            margin-bottom: 0.5rem;
+        }
+
+        .note-card p {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            line-height: 1.6;
+            opacity: 0.7;
+        }
+
+        .cta-strip {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            align-items: center;
+            justify-content: space-between;
+            padding: 2rem;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+
+        .cta-strip h3 {
+            font-size: 1.4rem;
+            font-weight: 400;
+            font-style: normal;
+        }
+
+        .cta-strip p {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.95rem;
+            font-weight: 300;
+            opacity: 0.7;
+            max-width: 520px;
+        }
+
+        .cta-actions {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .cta-actions a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            letter-spacing: 0.5px;
+            padding: 0.6rem 1.4rem;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.06);
+            transition: background 0.3s, border-color 0.3s;
+        }
+
+        .cta-actions a:hover {
+            background: rgba(255, 255, 255, 0.14);
+            border-color: rgba(255, 255, 255, 0.45);
+        }
+
+        .footer {
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+
+        .footer span {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            opacity: 0.4;
+        }
+
+        .footer-links {
+            display: flex;
+            gap: 1.25rem;
+        }
+
+        .footer-links a {
+            color: rgba(255, 255, 255, 0.5);
+            text-decoration: none;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            transition: opacity 0.3s;
+        }
+
+        .footer-links a:hover {
+            opacity: 0.6;
+        }
+
+        .fade-in {
+            opacity: 0;
+            transform: translateY(20px);
+            transition: opacity 0.8s ease, transform 0.8s ease;
+        }
+
+        .fade-in.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .fade-in-delay-1 { transition-delay: 0.1s; }
+        .fade-in-delay-2 { transition-delay: 0.2s; }
+        .fade-in-delay-3 { transition-delay: 0.3s; }
+
+        @media (max-width: 768px) {
+            .page-content h1 {
+                font-size: 2rem;
+            }
+
+            .projects-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .project-card {
+                aspect-ratio: 5 / 2;
+            }
+
+            .cta-strip {
+                align-items: flex-start;
+            }
+
+            .footer {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <a href="/" class="logo">Alec (Jude) Wilson</a>
+            <ul class="nav-menu">
+                <li><a href="/">Home</a></li>
+                <li><a href="/projects" class="active">Projects</a></li>
+                <li><a href="/photo">Photography</a></li>
+                <li><a href="/#contact">Contact</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <div class="page-content">
+        <h1 class="fade-in">Projects</h1>
+        <p class="page-subtitle fade-in fade-in-delay-1">Product experiments, client collaborations, and side quests. Each project blends software, storytelling, and a love for tactile details.</p>
+
+        <div class="page-links fade-in fade-in-delay-2">
+            <a href="/projects" class="active">Overview</a>
+            <a href="/projects/template.html">Template Project</a>
+            <a href="/photo">Photography</a>
+        </div>
+
+        <h2 class="section-heading fade-in">Featured Projects</h2>
+        <div class="projects-grid fade-in fade-in-delay-1">
+            <a href="/projects/template.html" class="project-card">
+                <img src="/background.jpeg" alt="Project cover" loading="lazy" decoding="async">
+                <span class="project-meta">Web · 2025</span>
+                <div class="project-title">Latitude Notes</div>
+            </a>
+            <a href="/projects/template.html" class="project-card">
+                <img src="/background2.jpeg" alt="Project cover" loading="lazy" decoding="async">
+                <span class="project-meta">Mobile · 2024</span>
+                <div class="project-title">Crescent Studio</div>
+            </a>
+            <a href="/projects/template.html" class="project-card">
+                <img src="/background3.jpeg" alt="Project cover" loading="lazy" decoding="async">
+                <span class="project-meta">Tooling · 2023</span>
+                <div class="project-title">Signal Watch</div>
+            </a>
+        </div>
+
+        <h2 class="section-heading fade-in">Project Notes</h2>
+        <div class="project-notes fade-in fade-in-delay-1">
+            <div class="note-card">
+                <h3>Guiding principles</h3>
+                <p>Build calm interfaces, reinforce clarity, and let each decision ladder up to a story users can feel.</p>
+            </div>
+            <div class="note-card">
+                <h3>Collaboration</h3>
+                <p>Partnering with founders and teams to map what success looks like before shipping a single screen.</p>
+            </div>
+            <div class="note-card">
+                <h3>Current focus</h3>
+                <p>Fast prototypes, design systems, and lightweight automations that keep creative teams moving.</p>
+            </div>
+        </div>
+
+        <div class="cta-strip fade-in">
+            <div>
+                <h3>Want the deeper story?</h3>
+                <p>Each project page walks through the process, the decisions, and the visuals behind the build.</p>
+            </div>
+            <div class="cta-actions">
+                <a href="/projects/template.html">View a case study</a>
+                <a href="/about.html">About me</a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="footer">
+        <span>&copy; 2026 Alec (Jude) Wilson</span>
+        <div class="footer-links">
+            <a href="/">Home</a>
+            <a href="https://github.com/alechash" target="_blank">GitHub</a>
+            <a href="https://x.com/alechash" target="_blank">X</a>
+        </div>
+    </footer>
+
+    <script>
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+    </script>
+</body>
+</html>

--- a/projects/template.html
+++ b/projects/template.html
@@ -1,0 +1,533 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Template | Alec (Jude) Wilson</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+    <meta name="description" content="Template project page for Alec (Jude) Wilson's portfolio.">
+    <meta property="og:title" content="Project Template | Alec (Jude) Wilson">
+    <meta property="og:description" content="Template project page for Alec (Jude) Wilson's portfolio.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="/bg.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@100..900&display=swap" rel="stylesheet">
+    <style>
+        html {
+            scroll-behavior: smooth;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Instrument Serif', serif;
+            font-style: italic;
+            min-height: 100vh;
+            background: #111;
+            color: white;
+        }
+
+        .navbar {
+            position: fixed;
+            top: 0;
+            right: 0;
+            left: 0;
+            z-index: 1000;
+            padding: 1.5rem 2rem;
+        }
+
+        .nav-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: 400;
+            letter-spacing: 0.5px;
+            color: white;
+            font-family: 'Instrument Serif', serif;
+            font-style: italic;
+            padding: 0.5rem 1.5rem;
+            background: radial-gradient(ellipse 150% 100% at center, rgba(10, 61, 44, 0.4) 0%, transparent 100%);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            text-decoration: none;
+        }
+
+        .nav-menu {
+            display: flex;
+            list-style: none;
+            gap: 0.5rem;
+        }
+
+        .nav-menu a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 300;
+            letter-spacing: 0.5px;
+            transition: opacity 0.3s;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            padding: 0.5rem 0.5rem;
+            display: block;
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            transform: scaleX(0.8);
+            background: radial-gradient(ellipse 150% 100% at center, rgba(10, 61, 44, 0.4) 0%, transparent 100%);
+        }
+
+        .nav-menu a:hover {
+            opacity: 0.6;
+        }
+
+        @media (max-width: 500px) {
+            .navbar {
+                padding: 1.5rem 1.5rem;
+            }
+
+            .nav-container {
+                align-items: flex-start;
+            }
+
+            .nav-menu {
+                flex-direction: column;
+                gap: 0.5rem;
+                text-align: right;
+            }
+
+            .nav-menu a {
+                font-size: 0.85rem;
+            }
+        }
+
+        .page-content {
+            padding: 8rem 2rem 4rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .page-content h1 {
+            font-size: 3rem;
+            font-weight: 400;
+            margin-bottom: 0.75rem;
+            letter-spacing: 0.5px;
+            font-style: normal;
+        }
+
+        .page-subtitle {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 1rem;
+            font-weight: 300;
+            opacity: 0.6;
+            margin-bottom: 2.5rem;
+            line-height: 1.6;
+            max-width: 720px;
+        }
+
+        .hero-card {
+            position: relative;
+            border-radius: 16px;
+            overflow: hidden;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            margin-bottom: 3rem;
+        }
+
+        .hero-card img {
+            width: 100%;
+            height: 360px;
+            object-fit: cover;
+            display: block;
+        }
+
+        .hero-overlay {
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(0,0,0,0.2) 0%, rgba(0,0,0,0.7) 100%);
+        }
+
+        .hero-details {
+            position: absolute;
+            left: 2rem;
+            bottom: 2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            z-index: 1;
+        }
+
+        .hero-tags {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .hero-tag {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.8rem;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+            padding: 0.35rem 0.8rem;
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            background: rgba(17, 17, 17, 0.5);
+            backdrop-filter: blur(12px);
+        }
+
+        .hero-actions {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+            margin-top: 0.5rem;
+        }
+
+        .hero-actions a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            letter-spacing: 0.5px;
+            padding: 0.6rem 1.4rem;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.06);
+            transition: background 0.3s, border-color 0.3s;
+        }
+
+        .hero-actions a:hover {
+            background: rgba(255, 255, 255, 0.14);
+            border-color: rgba(255, 255, 255, 0.45);
+        }
+
+        .meta-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 1rem;
+            margin-bottom: 3rem;
+        }
+
+        .meta-card {
+            padding: 1.5rem;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.04);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+
+        .meta-card span {
+            display: block;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.75rem;
+            letter-spacing: 0.6px;
+            text-transform: uppercase;
+            opacity: 0.5;
+            margin-bottom: 0.4rem;
+        }
+
+        .meta-card strong {
+            font-size: 1.1rem;
+            font-weight: 400;
+            font-style: normal;
+        }
+
+        .section-heading {
+            font-size: 1.6rem;
+            font-weight: 400;
+            font-style: normal;
+            margin-bottom: 1.25rem;
+            letter-spacing: 0.3px;
+        }
+
+        .section-text {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 1rem;
+            font-weight: 300;
+            line-height: 1.7;
+            opacity: 0.7;
+            max-width: 820px;
+        }
+
+        .section-split {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 1.5rem;
+            margin-bottom: 3rem;
+        }
+
+        .highlight-card {
+            padding: 1.5rem;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .highlight-card h3 {
+            font-size: 1.1rem;
+            font-weight: 400;
+            font-style: normal;
+            margin-bottom: 0.5rem;
+        }
+
+        .highlight-card p {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.95rem;
+            font-weight: 300;
+            line-height: 1.6;
+            opacity: 0.7;
+        }
+
+        .gallery-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 0.75rem;
+            margin-bottom: 3rem;
+        }
+
+        .gallery-item {
+            position: relative;
+            aspect-ratio: 4 / 3;
+            overflow: hidden;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.04);
+        }
+
+        .gallery-item img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .next-project {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: center;
+            padding: 2rem;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.05);
+        }
+
+        .next-project h3 {
+            font-size: 1.4rem;
+            font-weight: 400;
+            font-style: normal;
+        }
+
+        .next-project a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            letter-spacing: 0.5px;
+            padding: 0.6rem 1.4rem;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.06);
+            transition: background 0.3s, border-color 0.3s;
+        }
+
+        .next-project a:hover {
+            background: rgba(255, 255, 255, 0.14);
+            border-color: rgba(255, 255, 255, 0.45);
+        }
+
+        .footer {
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+
+        .footer span {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            opacity: 0.4;
+        }
+
+        .footer-links {
+            display: flex;
+            gap: 1.25rem;
+        }
+
+        .footer-links a {
+            color: rgba(255, 255, 255, 0.5);
+            text-decoration: none;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            transition: opacity 0.3s;
+        }
+
+        .footer-links a:hover {
+            opacity: 0.6;
+        }
+
+        .fade-in {
+            opacity: 0;
+            transform: translateY(20px);
+            transition: opacity 0.8s ease, transform 0.8s ease;
+        }
+
+        .fade-in.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .fade-in-delay-1 { transition-delay: 0.1s; }
+        .fade-in-delay-2 { transition-delay: 0.2s; }
+        .fade-in-delay-3 { transition-delay: 0.3s; }
+
+        @media (max-width: 768px) {
+            .page-content h1 {
+                font-size: 2rem;
+            }
+
+            .hero-card img {
+                height: 240px;
+            }
+
+            .hero-details {
+                left: 1.5rem;
+                right: 1.5rem;
+            }
+
+            .footer {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <a href="/" class="logo">Alec (Jude) Wilson</a>
+            <ul class="nav-menu">
+                <li><a href="/">Home</a></li>
+                <li><a href="/projects">Projects</a></li>
+                <li><a href="/photo">Photography</a></li>
+                <li><a href="/#contact">Contact</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <div class="page-content">
+        <h1 class="fade-in">Latitude Notes</h1>
+        <p class="page-subtitle fade-in fade-in-delay-1">A lightweight project journal that helps remote teams track launches, rituals, and the momentum between milestones.</p>
+
+        <div class="hero-card fade-in fade-in-delay-2">
+            <img src="/background4.jpg" alt="Project hero" loading="lazy" decoding="async">
+            <div class="hero-overlay"></div>
+            <div class="hero-details">
+                <div class="hero-tags">
+                    <span class="hero-tag">Product</span>
+                    <span class="hero-tag">UI/UX</span>
+                    <span class="hero-tag">2026</span>
+                </div>
+                <div class="hero-actions">
+                    <a href="#">View prototype</a>
+                    <a href="#">Read notes</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="meta-grid fade-in">
+            <div class="meta-card">
+                <span>Role</span>
+                <strong>Design + Engineering</strong>
+            </div>
+            <div class="meta-card">
+                <span>Timeline</span>
+                <strong>8 weeks</strong>
+            </div>
+            <div class="meta-card">
+                <span>Stack</span>
+                <strong>React, Node, Supabase</strong>
+            </div>
+            <div class="meta-card">
+                <span>Status</span>
+                <strong>In exploration</strong>
+            </div>
+        </div>
+
+        <h2 class="section-heading fade-in">Overview</h2>
+        <p class="section-text fade-in fade-in-delay-1">Latitude Notes was designed for distributed teams that need a shared sense of progress without heavyweight tooling. The product pairs a calm writing surface with just-enough structure: daily prompts, launch check-ins, and a highlight reel of momentum.</p>
+
+        <div class="section-split fade-in fade-in-delay-2">
+            <div class="highlight-card">
+                <h3>Challenge</h3>
+                <p>Teams were losing context between meetings. The goal was to build a space that felt intentional, but never overwhelming.</p>
+            </div>
+            <div class="highlight-card">
+                <h3>Approach</h3>
+                <p>Start with writing first, layer in rituals second. The UI uses soft gradients, glassy surfaces, and slow motion.</p>
+            </div>
+            <div class="highlight-card">
+                <h3>Outcome</h3>
+                <p>Early testers reported higher clarity in weekly planning, with a calmer end-of-week recap workflow.</p>
+            </div>
+        </div>
+
+        <h2 class="section-heading fade-in">Gallery</h2>
+        <div class="gallery-grid fade-in fade-in-delay-1">
+            <div class="gallery-item"><img src="/background.jpeg" alt="Project screen" loading="lazy" decoding="async"></div>
+            <div class="gallery-item"><img src="/background2.jpeg" alt="Project screen" loading="lazy" decoding="async"></div>
+            <div class="gallery-item"><img src="/background3.jpeg" alt="Project screen" loading="lazy" decoding="async"></div>
+            <div class="gallery-item"><img src="/bg.png" alt="Project screen" loading="lazy" decoding="async"></div>
+        </div>
+
+        <div class="next-project fade-in">
+            <div>
+                <h3>Next project</h3>
+                <p class="page-subtitle" style="margin-bottom: 0;">See how the other builds evolve in the full projects overview.</p>
+            </div>
+            <a href="/projects">Back to projects</a>
+        </div>
+    </div>
+
+    <footer class="footer">
+        <span>&copy; 2026 Alec (Jude) Wilson</span>
+        <div class="footer-links">
+            <a href="/">Home</a>
+            <a href="https://github.com/alechash" target="_blank">GitHub</a>
+            <a href="https://x.com/alechash" target="_blank">X</a>
+        </div>
+    </footer>
+
+    <script>
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Keep the horizontal photo scroller images reasonably small on desktop so the layout and buttons don’t get pushed out of frame. 
- Add a Projects overview and a Template Project page that follow the same visual language and interaction patterns used on the home, 404, and photo pages. 

### Description
- Tightened the desktop photo grid sizing in `index.html` by changing the grid to `repeat(auto-fit, minmax(180px, 1fr))`, setting items to `aspect-ratio: 4 / 3` and a controlled `height: clamp(160px, 18vw, 220px)`, and ensuring the mobile horizontal scroller retains its existing behavior. 
- Added a `Projects` navigation link to `index.html`, `photo.html`, and `404.html` for consistent navigation. 
- Added a new projects overview page at `projects/index.html` that mirrors the photo/home design patterns with featured cards, notes, and CTAs. 
- Added a template project detail page at `projects/template.html` with hero, metadata, highlights, and gallery sections to use as a case-study scaffold. 

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the site served the new pages successfully. 
- Ran a Playwright script to open `http://127.0.0.1:8000/projects/` and capture a visual snapshot, which produced the artifact at `artifacts/projects-overview.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ace452aa08330807b0752bb469a9f)