### PR TITLE
Use photo API for photography page

### DIFF
--- a/photo.html
+++ b/photo.html
@@ -245,12 +245,15 @@
             border: 1px solid rgba(255, 255, 255, 0.06);
             overflow: hidden;
             position: relative;
+            display: flex;
+            flex-direction: column;
         }
 
         .photo-grid-item a {
             display: block;
             width: 100%;
             height: 100%;
+            flex: 1;
         }
 
         .photo-grid-item img {
@@ -262,6 +265,26 @@
 
         .photo-grid-item:hover img {
             transform: scale(1.05);
+        }
+
+        .photo-grid-item figcaption {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.75rem;
+            font-weight: 300;
+            padding: 0.6rem 0.75rem 0.75rem;
+            line-height: 1.4;
+            color: rgba(255, 255, 255, 0.7);
+            background: rgba(0, 0, 0, 0.5);
+        }
+
+        .photo-grid-item figcaption a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+        }
+
+        .photo-grid-item figcaption a:hover {
+            text-decoration: underline;
         }
 
         /* Collection modal */
@@ -433,6 +456,30 @@
             gap: 1rem;
         }
 
+        .lightbox-attribution {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .lightbox-attribution a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+        }
+
+        .lightbox-attribution a:hover {
+            text-decoration: underline;
+        }
+
+        .status-text {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.95rem;
+            font-weight: 300;
+            opacity: 0.7;
+        }
         .lightbox-btn {
             color: rgba(255, 255, 255, 0.8);
             text-decoration: none;
@@ -583,6 +630,7 @@
     <div class="lightbox-overlay" id="lightbox">
         <div class="lightbox-content">
             <img id="lightbox-img" src="" alt="Photo">
+            <p class="lightbox-attribution" id="lightbox-attribution"></p>
             <div class="lightbox-actions">
                 <a id="lightbox-download" class="lightbox-btn" href="" download>Download</a>
                 <button class="lightbox-btn" id="lightbox-close">Close</button>
@@ -601,62 +649,96 @@
     </div>
 
     <script>
-        // All photos grid
-        var html = "";
-        for (var i = 0; i < 30; i++) {
-            html += `
-            <div class="photo-grid-item">
-                <a href="/assets/images/home/image_${i}.jpg">
-                    <img src="/assets/images/home/image_${i}.jpg" alt="Image ${i}" loading="lazy" decoding="async">
+        const apiBase = "https://judes-club-photos.hi-eab.workers.dev";
+        const imagesGrid = document.getElementById("images");
+        const galleryGrid = document.getElementById("gallery");
+
+        function renderAttribution(photo) {
+            const name = photo.user_name || "Unknown";
+            const profile = photo.user_profile || "#";
+            const link = photo.attribution_url || "#";
+            return `Photo by <a href="${profile}" target="_blank" rel="noopener">${name}</a> on <a href="${link}" target="_blank" rel="noopener">Unsplash</a>`;
+        }
+
+        function escapeAttr(value) {
+            return String(value || "")
+                .replace(/&/g, "&amp;")
+                .replace(/"/g, "&quot;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/'/g, "&#39;");
+        }
+
+        function renderPhotoItem(photo) {
+            const altText = photo.alt_description || photo.description || "Photo";
+            return `
+                <figure class="photo-grid-item">
+                    <a href="${photo.url_regular}"
+                        data-url="${escapeAttr(photo.url_regular)}"
+                        data-alt="${escapeAttr(altText)}"
+                        data-user-name="${escapeAttr(photo.user_name || "Unknown")}"
+                        data-user-profile="${escapeAttr(photo.user_profile || "#")}"
+                        data-attribution-url="${escapeAttr(photo.attribution_url || "#")}">
+                        <img src="${photo.url_regular}" alt="${altText}" loading="lazy" decoding="async">
+                    </a>
+                    <figcaption>${renderAttribution(photo)}</figcaption>
+                </figure>
+            `;
+        }
+
+        function renderCollectionCard(collection, coverPhoto, index) {
+            const coverUrl = coverPhoto?.url_regular || coverPhoto?.url_small || "";
+            const altText = coverPhoto?.alt_description || collection.title || "Collection cover";
+            return `
+                <a href="#" class="collection-card" data-collection-id="${collection.id}" data-index="${index}">
+                    <img src="${coverUrl}" alt="${altText}" loading="lazy" decoding="async">
+                    <div class="collection-title">${collection.title}</div>
                 </a>
-            </div>`;
+            `;
         }
-        document.getElementById("images").innerHTML = html;
 
-        // Collections
-        const projects = [
-            {
-                title: "Rice Farm Horses",
-                cover: "rice_horses/img_2",
-                desc: "",
-                album: { folder: "rice_horses", photo_prefix: "img_", photo_index: 15 },
-            },
-            {
-                title: "PNS Car Shoot: 1/3/24",
-                cover: "wrx_shoot/img-1",
-                desc: "",
-                album: { folder: "wrx_shoot", photo_prefix: "img-", photo_index: 12 },
-            },
-            {
-                title: "Rocket",
-                cover: "rocket/img-5",
-                desc: "",
-                album: { folder: "rocket", photo_prefix: "img-", photo_index: 6 },
-            },
-            {
-                title: "Ecuador 23",
-                cover: "ecuador/img-24",
-                desc: "",
-                album: { folder: "ecuador", photo_prefix: "img-", photo_index: 27 },
-            },
-            {
-                title: "Real Estate Example",
-                cover: "re/img_0",
-                desc: "",
-                album: { folder: "re", photo_prefix: "img_", photo_index: 52 },
-            },
-        ];
-
-        // Render collection cards
-        var projectHtml = "";
-        for (var i = 0; i < projects.length; i++) {
-            projectHtml += `
-            <a href="#" class="collection-card" data-project="${i}">
-                <img src="/assets/images/${projects[i].cover}.jpg" alt="${projects[i].title}" loading="lazy" decoding="async">
-                <div class="collection-title">${projects[i].title}</div>
-            </a>`;
+        async function fetchJson(url) {
+            const res = await fetch(url);
+            if (!res.ok) {
+                throw new Error(`Request failed: ${res.status}`);
+            }
+            return res.json();
         }
-        document.getElementById("gallery").innerHTML = projectHtml;
+
+        async function loadAllPhotos() {
+            imagesGrid.innerHTML = '<p class="status-text">Loading photos...</p>';
+            try {
+                const data = await fetchJson(`${apiBase}/photos`);
+                const photos = data.results || [];
+                imagesGrid.innerHTML = photos.map(renderPhotoItem).join("");
+            } catch (error) {
+                imagesGrid.innerHTML = '<p class="status-text">Unable to load photos right now.</p>';
+                console.error(error);
+            }
+        }
+
+        async function loadCollections() {
+            galleryGrid.innerHTML = '<p class="status-text">Loading collections...</p>';
+            try {
+                const data = await fetchJson(`${apiBase}/collections`);
+                const collections = data.results || [];
+                const coverPhotos = await Promise.all(
+                    collections.map((collection) => {
+                        if (!collection.cover_photo_id) {
+                            return null;
+                        }
+                        return fetchJson(`${apiBase}/photos/${collection.cover_photo_id}`).catch(() => null);
+                    })
+                );
+                galleryGrid.innerHTML = collections.map((collection, index) => renderCollectionCard(collection, coverPhotos[index], index)).join("");
+            } catch (error) {
+                galleryGrid.innerHTML = '<p class="status-text">Unable to load collections right now.</p>';
+                console.error(error);
+            }
+        }
+
+        loadAllPhotos();
+        loadCollections();
 
         // Modal logic
         const modal = document.getElementById('collection-modal');
@@ -664,20 +746,18 @@
         const modalImages = document.getElementById('collection_images');
         const modalClose = document.getElementById('modal-close');
 
-        function openCollection(index) {
-            const p = projects[index];
-            modalTitle.innerText = p.title;
+        async function openCollection(collectionId, title) {
+            modalTitle.innerText = title;
+            modalImages.innerHTML = '<p class="status-text">Loading collection...</p>';
 
-            var photosHtml = "";
-            for (var j = 0; j < p.album.photo_index; j++) {
-                photosHtml += `
-                <div class="photo-grid-item">
-                    <a href="/assets/images/${p.album.folder}/${p.album.photo_prefix}${j}.jpg">
-                        <img src="/assets/images/${p.album.folder}/${p.album.photo_prefix}${j}.jpg" alt="Image ${j}" loading="lazy" decoding="async">
-                    </a>
-                </div>`;
+            try {
+                const data = await fetchJson(`${apiBase}/collections/${collectionId}/photos`);
+                const photos = data.results || [];
+                modalImages.innerHTML = photos.map(renderPhotoItem).join("");
+            } catch (error) {
+                modalImages.innerHTML = '<p class="status-text">Unable to load this collection right now.</p>';
+                console.error(error);
             }
-            modalImages.innerHTML = photosHtml;
 
             modal.style.display = 'block';
             modal.scrollTop = 0;
@@ -704,7 +784,7 @@
             const card = e.target.closest('.collection-card');
             if (card) {
                 e.preventDefault();
-                openCollection(Number(card.dataset.project));
+                openCollection(card.dataset.collectionId, card.querySelector('.collection-title')?.textContent || "Collection");
             }
         });
 
@@ -723,10 +803,13 @@
         const lightboxImg = document.getElementById('lightbox-img');
         const lightboxDownload = document.getElementById('lightbox-download');
         const lightboxCloseBtn = document.getElementById('lightbox-close');
+        const lightboxAttribution = document.getElementById('lightbox-attribution');
 
-        function openLightbox(src) {
-            lightboxImg.src = src;
-            lightboxDownload.href = src;
+        function openLightbox(photo) {
+            lightboxImg.src = photo.url_regular;
+            lightboxImg.alt = photo.alt_description || photo.description || "Photo";
+            lightboxDownload.href = photo.url_regular;
+            lightboxAttribution.innerHTML = renderAttribution(photo);
             lightbox.style.display = 'flex';
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
@@ -744,6 +827,7 @@
                 lightbox.style.display = 'none';
                 document.body.style.overflow = modal.classList.contains('active') ? 'hidden' : '';
                 lightboxImg.src = '';
+                lightboxAttribution.innerHTML = '';
             }, 400);
         }
 
@@ -751,7 +835,14 @@
             const item = e.target.closest('.photo-grid-item a');
             if (item) {
                 e.preventDefault();
-                openLightbox(item.href);
+                const photo = {
+                    url_regular: item.dataset.url || item.href,
+                    alt_description: item.dataset.alt || "Photo",
+                    user_name: item.dataset.userName || "Unknown",
+                    user_profile: item.dataset.userProfile || "#",
+                    attribution_url: item.dataset.attributionUrl || "#",
+                };
+                openLightbox(photo);
             }
         });
 


### PR DESCRIPTION
### Motivation
- Replace hard-coded local images with the remote photos API to serve up-to-date photos and centralize content.
- Include proper Unsplash attribution and basic loading/error states to comply with licensing and improve UX.

### Description
- Added `apiBase = "https://judes-club-photos.hi-eab.workers.dev"` and replaced the static image grid and local `projects` array with API-driven functions `loadAllPhotos()` and `loadCollections()` that fetch `/photos` and `/collections`.
- Implemented `renderPhotoItem`, `renderCollectionCard`, `renderAttribution`, and `escapeAttr` to safely render photo markup and attribution in the grid and modal.
- Updated the collection modal to fetch collection photos from `/collections/:id/photos` and made the lightbox accept a photo object so it shows the `url_regular`, `alt` text, download link, and Unsplash attribution.
- CSS tweaks: added caption styling, lightbox attribution, and `status-text` for loading/error messaging, and adjusted photo item layout to support captions.

### Testing
- Started a local static server with `python -m http.server 8000` and exercised the page with a Playwright script that opened `http://localhost:8000/photo.html` and captured a screenshot as `artifacts/photo-page.png`, which completed successfully.
- Manual smoke test via the browser screenshot confirmed the page loads and renders the new grids (no automated unit tests exist for this static HTML change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c2026d5cc8330b66a46cf1ee547b9)