### PR TITLE
Use remote photo API on photography page

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,45 +914,103 @@
     </section>
 
     <script>
-        // Build pool of all site photos and pick 4 random unique ones
+        // Build pool of Unsplash photos and pick 8 random ones
         (function() {
-            const photos = [
-                '/bg.jpeg', '/background.jpeg', '/background2.jpeg', '/background3.jpeg', '/background4.jpeg',
-                '/img_1.jpg', '/img_2.jpeg', '/img_3.jpeg', '/img_4.jpeg',
-                '/assets/main.jpg',
-            ];
-            for (let i = 0; i <= 26; i++) photos.push(`/assets/images/ecuador/img-${i}.jpg`);
-            for (let i = 0; i <= 29; i++) photos.push(`/assets/images/home/image_${i}.jpg`);
-            for (let i = 0; i <= 5; i++) photos.push(`/assets/images/rocket/img-${i}.jpg`);
+            const API_BASE = "https://judes-club-photos.hi-eab.workers.dev";
+            const CACHE_TTL = 24 * 60 * 60 * 1000;
+            const grid = document.getElementById('photo-grid');
+            const prevBtn = document.getElementById('carousel-prev');
+            const nextBtn = document.getElementById('carousel-next');
+            let count = 0;
+            let ci = 0;
 
-            // Fisher-Yates shuffle, pick first 8
-            for (let i = photos.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
-                [photos[i], photos[j]] = [photos[j], photos[i]];
+            function getCacheKey(key) {
+                return `judes-home-cache:${key}`;
             }
 
-            const grid = document.getElementById('photo-grid');
-            photos.slice(0, 8).forEach((src, i) => {
-                const div = document.createElement('div');
-                div.className = 'photo-grid-item';
-                const img = document.createElement('img');
-                img.src = src;
-                img.alt = 'Photo';
-                img.loading = 'lazy';
-                img.decoding = 'async';
-                div.appendChild(img);
-                grid.appendChild(div);
-            });
+            function getCachedData(key) {
+                try {
+                    const raw = localStorage.getItem(getCacheKey(key));
+                    if (!raw) return null;
+                    const cached = JSON.parse(raw);
+                    if (Date.now() - cached.timestamp > CACHE_TTL) {
+                        localStorage.removeItem(getCacheKey(key));
+                        return null;
+                    }
+                    return cached.data;
+                } catch (error) {
+                    console.error(error);
+                    return null;
+                }
+            }
 
-            // Carousel buttons — slide via translateX
-            var count = grid.querySelectorAll('.photo-grid-item').length;
-            var ci = 0;
+            function setCachedData(key, data) {
+                try {
+                    localStorage.setItem(getCacheKey(key), JSON.stringify({
+                        timestamp: Date.now(),
+                        data,
+                    }));
+                } catch (error) {
+                    console.error(error);
+                }
+            }
+
+            async function fetchJson(url) {
+                const response = await fetch(url);
+                if (!response.ok) {
+                    throw new Error(`Request failed: ${response.status}`);
+                }
+                return response.json();
+            }
+
+            async function fetchJsonCached(url, cacheKey) {
+                const cached = getCachedData(cacheKey);
+                if (cached) {
+                    return cached;
+                }
+                const data = await fetchJson(url);
+                setCachedData(cacheKey, data);
+                return data;
+            }
+
             function slideTo(i) {
+                if (!count) return;
                 ci = ((i % count) + count) % count;
                 grid.style.transform = 'translateX(-' + (ci * 100) + '%)';
             }
-            document.getElementById('carousel-prev').addEventListener('click', function() { slideTo(ci - 1); });
-            document.getElementById('carousel-next').addEventListener('click', function() { slideTo(ci + 1); });
+
+            prevBtn.addEventListener('click', function() { slideTo(ci - 1); });
+            nextBtn.addEventListener('click', function() { slideTo(ci + 1); });
+
+            async function loadPhotos() {
+                const data = await fetchJsonCached(`${API_BASE}/photos?page=1&limit=50`, 'home-photos');
+                const photos = data.results || [];
+                if (!photos.length) return;
+
+                // Fisher-Yates shuffle, pick first 8
+                for (let i = photos.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    [photos[i], photos[j]] = [photos[j], photos[i]];
+                }
+
+                grid.innerHTML = "";
+                photos.slice(0, 8).forEach((photo) => {
+                    const div = document.createElement('div');
+                    div.className = 'photo-grid-item';
+                    const img = document.createElement('img');
+                    img.src = photo.url_small || photo.url_regular;
+                    img.alt = photo.alt_description || 'Photo';
+                    img.loading = 'lazy';
+                    img.decoding = 'async';
+                    div.appendChild(img);
+                    grid.appendChild(div);
+                });
+
+                count = grid.querySelectorAll('.photo-grid-item').length;
+                slideTo(0);
+            }
+
+            loadPhotos().catch((error) => console.error(error));
         })();
 
         // Fade-in: trigger when section becomes active

--- a/index.html
+++ b/index.html
@@ -610,6 +610,7 @@
             display: grid;
             grid-template-columns: repeat(4, 1fr);
             gap: 0.75rem;
+            row-gap: 0;
         }
 
         .photo-grid-item {
@@ -634,6 +635,15 @@
             transform: scale(1.05);
         }
 
+        .photo-grid-item button {
+            width: 100%;
+            height: 100%;
+            border: none;
+            background: transparent;
+            padding: 0;
+            cursor: pointer;
+        }
+
         .photo-grid-placeholder {
             width: 100%;
             height: 100%;
@@ -647,6 +657,110 @@
             color: rgba(255, 255, 255, 0.25);
             letter-spacing: 1px;
             text-transform: uppercase;
+        }
+
+        /* Home lightbox */
+        .home-lightbox {
+            display: none;
+            position: fixed;
+            inset: 0;
+            z-index: 2000;
+            background: rgba(0, 0, 0, 0);
+            backdrop-filter: blur(0px);
+            -webkit-backdrop-filter: blur(0px);
+            opacity: 0;
+            transition: opacity 0.35s ease, background 0.35s ease, backdrop-filter 0.35s ease, -webkit-backdrop-filter 0.35s ease;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .home-lightbox.active {
+            opacity: 1;
+            background: rgba(0, 0, 0, 0.92);
+            backdrop-filter: blur(14px);
+            -webkit-backdrop-filter: blur(14px);
+        }
+
+        .home-lightbox.closing {
+            opacity: 0;
+            background: rgba(0, 0, 0, 0);
+            backdrop-filter: blur(0px);
+            -webkit-backdrop-filter: blur(0px);
+        }
+
+        .home-lightbox-content {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1.5rem;
+            transform: scale(0.95) translateY(10px);
+            opacity: 0;
+            transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.35s ease;
+            max-width: 90vw;
+            max-height: 90vh;
+        }
+
+        .home-lightbox.active .home-lightbox-content {
+            transform: scale(1) translateY(0);
+            opacity: 1;
+        }
+
+        .home-lightbox.closing .home-lightbox-content {
+            transform: scale(0.95) translateY(10px);
+            opacity: 0;
+        }
+
+        .home-lightbox-content img {
+            max-width: 90vw;
+            max-height: 75vh;
+            object-fit: contain;
+        }
+
+        .home-lightbox-actions {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+
+        .home-lightbox-btn {
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            padding: 0.6rem 1.5rem;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            cursor: pointer;
+            background: rgba(255, 255, 255, 0.06);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+            transition: background 0.3s, border-color 0.3s;
+        }
+
+        .home-lightbox-btn:hover {
+            background: rgba(255, 255, 255, 0.14);
+            border-color: rgba(255, 255, 255, 0.45);
+            color: white;
+        }
+
+        .home-lightbox-attribution {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.7);
+            text-align: center;
+        }
+
+        .home-lightbox-attribution a {
+            color: rgba(255, 255, 255, 0.85);
+            text-decoration: none;
+        }
+
+        .home-lightbox-attribution a:hover {
+            opacity: 0.7;
         }
 
         /* Form status */
@@ -913,6 +1027,18 @@
         <span class="photo-caption">The Sky, Earth</span>
     </section>
 
+    <div class="home-lightbox" id="home-lightbox">
+        <div class="home-lightbox-content">
+            <img id="home-lightbox-img" src="" alt="Photo">
+            <div class="home-lightbox-actions">
+                <a id="home-lightbox-download" class="home-lightbox-btn" href="" download>Download</a>
+                <a class="home-lightbox-btn" href="/photo">View More</a>
+                <button class="home-lightbox-btn" id="home-lightbox-close">Close</button>
+            </div>
+            <p class="home-lightbox-attribution" id="home-lightbox-attribution"></p>
+        </div>
+    </div>
+
     <script>
         // Build pool of Unsplash photos and pick 8 random ones
         (function() {
@@ -921,6 +1047,11 @@
             const grid = document.getElementById('photo-grid');
             const prevBtn = document.getElementById('carousel-prev');
             const nextBtn = document.getElementById('carousel-next');
+            const lightbox = document.getElementById('home-lightbox');
+            const lightboxImg = document.getElementById('home-lightbox-img');
+            const lightboxDownload = document.getElementById('home-lightbox-download');
+            const lightboxClose = document.getElementById('home-lightbox-close');
+            const lightboxAttribution = document.getElementById('home-lightbox-attribution');
             let count = 0;
             let ci = 0;
 
@@ -982,6 +1113,57 @@
             prevBtn.addEventListener('click', function() { slideTo(ci - 1); });
             nextBtn.addEventListener('click', function() { slideTo(ci + 1); });
 
+            function openLightbox(data) {
+                lightboxImg.src = data.src;
+                lightboxImg.alt = data.alt || 'Photo';
+                lightboxDownload.href = data.src;
+                lightboxAttribution.innerHTML = `
+                    Photo by <a href="${data.userProfile}" target="_blank" rel="noopener">${data.userName}</a>
+                    on <a href="${data.attributionUrl}" target="_blank" rel="noopener">Unsplash</a>
+                `;
+                lightbox.style.display = 'flex';
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        lightbox.classList.add('active');
+                        document.body.style.overflow = 'hidden';
+                    });
+                });
+            }
+
+            function closeLightbox() {
+                lightbox.classList.add('closing');
+                lightbox.classList.remove('active');
+                setTimeout(() => {
+                    lightbox.classList.remove('closing');
+                    lightbox.style.display = 'none';
+                    document.body.style.overflow = '';
+                    lightboxImg.src = '';
+                    lightboxAttribution.innerHTML = '';
+                }, 400);
+            }
+
+            lightboxClose.addEventListener('click', closeLightbox);
+            lightbox.addEventListener('click', (event) => {
+                if (event.target === lightbox) closeLightbox();
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && lightbox.classList.contains('active')) closeLightbox();
+            });
+
+            grid.addEventListener('click', (event) => {
+                const button = event.target.closest('button[data-src]');
+                if (!button) return;
+                event.preventDefault();
+                openLightbox({
+                    src: button.dataset.src,
+                    alt: button.dataset.alt,
+                    userName: button.dataset.userName,
+                    userProfile: button.dataset.userProfile,
+                    attributionUrl: button.dataset.attributionUrl,
+                });
+            });
+
             async function loadPhotos() {
                 const data = await fetchJsonCached(`${API_BASE}/photos?page=1&limit=50`, 'home-photos');
                 const photos = data.results || [];
@@ -997,12 +1179,20 @@
                 photos.slice(0, 8).forEach((photo) => {
                     const div = document.createElement('div');
                     div.className = 'photo-grid-item';
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.dataset.src = photo.url_regular;
+                    button.dataset.alt = photo.alt_description || 'Photo';
+                    button.dataset.userName = photo.user_name;
+                    button.dataset.userProfile = photo.user_profile;
+                    button.dataset.attributionUrl = photo.attribution_url;
                     const img = document.createElement('img');
                     img.src = photo.url_small || photo.url_regular;
                     img.alt = photo.alt_description || 'Photo';
                     img.loading = 'lazy';
                     img.decoding = 'async';
-                    div.appendChild(img);
+                    button.appendChild(img);
+                    div.appendChild(button);
                     grid.appendChild(div);
                 });
 

--- a/photo.html
+++ b/photo.html
@@ -209,15 +209,45 @@
             flex-wrap: wrap;
         }
 
+        .sort-select-wrapper {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
         .sort-select {
+            appearance: none;
+            -webkit-appearance: none;
+            -moz-appearance: none;
             font-family: 'Inter', sans-serif;
             font-style: normal;
             font-size: 0.9rem;
             font-weight: 300;
             color: rgba(255, 255, 255, 0.9);
-            background: rgba(255, 255, 255, 0.06);
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            padding: 0.5rem 0.75rem;
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 999px;
+            padding: 0.5rem 2.5rem 0.5rem 1rem;
+            cursor: pointer;
+        }
+
+        .sort-select:focus {
+            outline: none;
+            border-color: rgba(255, 255, 255, 0.6);
+        }
+
+        .sort-select-wrapper::after {
+            content: "▾";
+            position: absolute;
+            right: 0.9rem;
+            color: rgba(255, 255, 255, 0.6);
+            pointer-events: none;
         }
 
         .collection-card {
@@ -311,13 +341,26 @@
             left: 0;
             right: 0;
             display: flex;
-            gap: 0.75rem;
-            padding: 0.5rem 0.75rem;
+            gap: 0.5rem;
+            padding: 0.5rem 0.6rem;
+            justify-content: flex-start;
+            flex-wrap: wrap;
             font-family: 'Inter', sans-serif;
             font-style: normal;
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             font-weight: 300;
-            background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
+            background: linear-gradient(to top, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+        }
+
+        .photo-stat {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.25rem 0.5rem;
+            border-radius: 999px;
+            background: rgba(0, 0, 0, 0.45);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            letter-spacing: 0.2px;
         }
 
         /* Collection modal */
@@ -640,10 +683,11 @@
 
         <div class="section-toolbar fade-in fade-in-delay-2">
             <h2 class="section-heading">Collections</h2>
-            <label>
+            <label class="sort-select-wrapper">
+                Sort
                 <span class="sr-only">Sort collections</span>
                 <select class="sort-select" id="collections-sort">
-                    <option value="views" selected>Sort by Views</option>
+                    <option value="views">Sort by Views</option>
                     <option value="downloads">Sort by Downloads</option>
                     <option value="latest">Sort by Latest</option>
                 </select>
@@ -653,10 +697,11 @@
 
         <div class="section-toolbar fade-in">
             <h2 class="section-heading">All Photos</h2>
-            <label>
+            <label class="sort-select-wrapper">
+                Sort
                 <span class="sr-only">Sort all photos</span>
                 <select class="sort-select" id="photos-sort">
-                    <option value="views" selected>Sort by Views</option>
+                    <option value="views">Sort by Views</option>
                     <option value="downloads">Sort by Downloads</option>
                     <option value="latest">Sort by Latest</option>
                 </select>
@@ -782,9 +827,9 @@
                         <img src="${imageUrl}" alt="${alt}" loading="lazy" decoding="async">
                     </a>
                     <div class="photo-stats">
-                        <span>❤ ${likes}</span>
-                        <span>👁 ${views}</span>
-                        <span>⬇ ${downloads}</span>
+                        <span class="photo-stat">Likes ${likes}</span>
+                        <span class="photo-stat">Views ${views}</span>
+                        <span class="photo-stat">Downloads ${downloads}</span>
                     </div>
                 </div>`;
         }
@@ -991,13 +1036,16 @@
 
         document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
 
+        photosSort.value = activePhotoSort;
+        collectionsSort.value = activeCollectionSort;
+
         photosSort.addEventListener('change', () => {
-            activePhotoSort = photosSort.value;
+            activePhotoSort = photosSort.value || "views";
             loadAllPhotos({ reset: true });
         });
 
         collectionsSort.addEventListener('change', () => {
-            activeCollectionSort = collectionsSort.value;
+            activeCollectionSort = collectionsSort.value || "views";
             loadCollections();
         });
 

--- a/photo.html
+++ b/photo.html
@@ -151,14 +151,21 @@
 
         .summary-stats {
             display: flex;
-            flex-wrap: wrap;
-            gap: 0.75rem;
-            margin-bottom: 3rem;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.5rem;
+            margin-bottom: 2rem;
             font-family: 'Inter', sans-serif;
             font-style: normal;
             font-size: 0.9rem;
             font-weight: 300;
             color: rgba(255, 255, 255, 0.75);
+        }
+
+        .summary-stat-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
         }
 
         .summary-stat {
@@ -175,6 +182,11 @@
             width: 0.9rem;
             height: 0.9rem;
             display: block;
+        }
+
+        .summary-note {
+            font-size: 0.8rem;
+            opacity: 0.6;
         }
 
         .page-links {
@@ -729,18 +741,7 @@
             <a href="https://judes.darkroom.com" target="_blank">Buy Prints</a>
         </div>
 
-        <div class="section-toolbar fade-in fade-in-delay-2">
-            <h2 class="section-heading">Collections</h2>
-            <label class="sort-select-wrapper">
-                Sort
-                <span class="sr-only">Sort collections</span>
-                <select class="sort-select" id="collections-sort">
-                    <option value="views">Sort by Views</option>
-                    <option value="downloads">Sort by Downloads</option>
-                    <option value="latest">Sort by Latest</option>
-                </select>
-            </label>
-        </div>
+        <h2 class="section-heading fade-in fade-in-delay-2">Collections</h2>
         <div class="collections-grid fade-in fade-in-delay-3" id="gallery"></div>
 
         <div class="section-toolbar fade-in">
@@ -796,7 +797,6 @@
         const imagesGrid = document.getElementById("images");
         const photoLoader = document.getElementById("photo-loader");
         const photosSort = document.getElementById("photos-sort");
-        const collectionsSort = document.getElementById("collections-sort");
         const summaryStats = document.getElementById("summary-stats");
         const modal = document.getElementById('collection-modal');
         const modalTitle = document.getElementById('collection_title');
@@ -813,7 +813,6 @@
         let isLoadingPhotos = false;
         let hasMorePhotos = true;
         let activePhotoSort = "views";
-        let activeCollectionSort = "views";
         const numberFormatter = new Intl.NumberFormat();
 
         function getCacheKey(key) {
@@ -911,26 +910,29 @@
 
         function renderSummaryStats(totals) {
             summaryStats.innerHTML = `
-                <span class="summary-stat" aria-label="Total likes ${totals.likes}">
-                    <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
-                        <path fill="#FF6B6B" d="M12 21s-7.2-4.7-9.5-9C.7 8.4 2 5.3 4.7 4.4c2.1-.7 4.2.1 5.6 1.8C11.7 4.5 13.8 3.7 16 4.4 18.7 5.3 20 8.4 19.5 12c-2.3 4.3-9.5 9-9.5 9z"/>
-                    </svg>
-                    ${totals.likes}
-                </span>
-                <span class="summary-stat" aria-label="Total views ${totals.views}">
-                    <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
-                        <path fill="#7BDFF2" d="M12 5C6.5 5 2 9.1 1 12c1 2.9 5.5 7 11 7s10-4.1 11-7c-1-2.9-5.5-7-11-7zm0 11a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/>
-                        <circle fill="#7BDFF2" cx="12" cy="12" r="2.2"/>
-                    </svg>
-                    ${totals.views}
-                </span>
-                <span class="summary-stat" aria-label="Total downloads ${totals.downloads}">
-                    <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
-                        <path fill="#B6E388" d="M12 3a1 1 0 0 1 1 1v9.2l2.6-2.6a1 1 0 1 1 1.4 1.4l-4.3 4.3a1 1 0 0 1-1.4 0L7 12a1 1 0 1 1 1.4-1.4L11 13.2V4a1 1 0 0 1 1-1z"/>
-                        <path fill="#B6E388" d="M5 19a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H6a1 1 0 0 1-1-1z"/>
-                    </svg>
-                    ${totals.downloads}
-                </span>
+                <div class="summary-stat-row">
+                    <span class="summary-stat" aria-label="Total likes ${totals.likes}">
+                        <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                            <path fill="#FF6B6B" d="M12 21s-7.2-4.7-9.5-9C.7 8.4 2 5.3 4.7 4.4c2.1-.7 4.2.1 5.6 1.8C11.7 4.5 13.8 3.7 16 4.4 18.7 5.3 20 8.4 19.5 12c-2.3 4.3-9.5 9-9.5 9z"/>
+                        </svg>
+                        ${totals.likes}
+                    </span>
+                    <span class="summary-stat" aria-label="Total views ${totals.views}">
+                        <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                            <path fill="#7BDFF2" d="M12 5C6.5 5 2 9.1 1 12c1 2.9 5.5 7 11 7s10-4.1 11-7c-1-2.9-5.5-7-11-7zm0 11a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/>
+                            <circle fill="#7BDFF2" cx="12" cy="12" r="2.2"/>
+                        </svg>
+                        ${totals.views}
+                    </span>
+                    <span class="summary-stat" aria-label="Total downloads ${totals.downloads}">
+                        <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                            <path fill="#B6E388" d="M12 3a1 1 0 0 1 1 1v9.2l2.6-2.6a1 1 0 1 1 1.4 1.4l-4.3 4.3a1 1 0 0 1-1.4 0L7 12a1 1 0 1 1 1.4-1.4L11 13.2V4a1 1 0 0 1 1-1z"/>
+                            <path fill="#B6E388" d="M5 19a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H6a1 1 0 0 1-1-1z"/>
+                        </svg>
+                        ${totals.downloads}
+                    </span>
+                </div>
+                <span class="summary-note">Stats via Unsplash.</span>
             `;
         }
 
@@ -1025,8 +1027,8 @@
             gallery.innerHTML = "<p>Loading collections...</p>";
             try {
                 const data = await fetchJsonCached(
-                    `${API_BASE}/collections?sort=${activeCollectionSort}`,
-                    `collections-${activeCollectionSort}`
+                    `${API_BASE}/collections`,
+                    "collections"
                 );
                 const collections = data.results || [];
                 const enrichedCollections = await Promise.all(collections.map(async (collection) => {
@@ -1075,8 +1077,8 @@
 
             try {
                 const data = await fetchJsonCached(
-                    `${API_BASE}/collections/${collectionId}/photos?sort=${activeCollectionSort}`,
-                    `collection-${collectionId}-photos-${activeCollectionSort}`
+                    `${API_BASE}/collections/${collectionId}/photos`,
+                    `collection-${collectionId}-photos`
                 );
                 const photos = data.results || [];
                 modalTitle.innerText = collectionTitle || "Collection";
@@ -1184,16 +1186,9 @@
         document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
 
         photosSort.value = activePhotoSort;
-        collectionsSort.value = activeCollectionSort;
-
         photosSort.addEventListener('change', () => {
             activePhotoSort = photosSort.value || "views";
             loadAllPhotos({ reset: true });
-        });
-
-        collectionsSort.addEventListener('change', () => {
-            activeCollectionSort = collectionsSort.value || "views";
-            loadCollections();
         });
 
         const infiniteObserver = new IntersectionObserver((entries) => {

--- a/photo.html
+++ b/photo.html
@@ -145,7 +145,7 @@
             font-size: 1rem;
             font-weight: 300;
             opacity: 0.5;
-            margin-bottom: 3rem;
+            margin-bottom: 1rem;
             line-height: 1.6;
         }
 
@@ -719,6 +719,7 @@
     <div class="page-content">
         <h1 class="fade-in">Photography</h1>
         <p class="page-subtitle fade-in fade-in-delay-1">Film and digital across Latin America, the US, Europe, Africa, and wherever else I end up.</p>
+        <div class="summary-stats fade-in fade-in-delay-3" id="summary-stats"></div>
         
         <p class="section-heading fade-in">Follow me</p>
         <div class="page-links fade-in fade-in-delay-2">
@@ -727,7 +728,6 @@
             <a href="https://glass.photo/wilude" target="_blank">on Glass</a>
             <a href="https://judes.darkroom.com" target="_blank">Buy Prints</a>
         </div>
-        <div class="summary-stats fade-in fade-in-delay-3" id="summary-stats"></div>
 
         <h2 class="section-heading fade-in fade-in-delay-2">Collections</h2>
         <div class="collections-grid fade-in fade-in-delay-3" id="gallery"></div>
@@ -931,7 +931,6 @@
                         ${totals.downloads}
                     </span>
                 </div>
-                <span class="summary-note">Stats via Unsplash.</span>
             `;
         }
 

--- a/photo.html
+++ b/photo.html
@@ -632,6 +632,7 @@
 
     <script>
         const API_BASE = "https://judes-club-photos.hi-eab.workers.dev";
+        const CACHE_TTL = 24 * 60 * 60 * 1000;
         const gallery = document.getElementById("gallery");
         const imagesGrid = document.getElementById("images");
         const photoLoader = document.getElementById("photo-loader");
@@ -650,12 +651,53 @@
         let isLoadingPhotos = false;
         let hasMorePhotos = true;
 
+        function getCacheKey(key) {
+            return `judes-photo-cache:${key}`;
+        }
+
+        function getCachedData(key) {
+            try {
+                const raw = localStorage.getItem(getCacheKey(key));
+                if (!raw) return null;
+                const cached = JSON.parse(raw);
+                if (Date.now() - cached.timestamp > CACHE_TTL) {
+                    localStorage.removeItem(getCacheKey(key));
+                    return null;
+                }
+                return cached.data;
+            } catch (error) {
+                console.error(error);
+                return null;
+            }
+        }
+
+        function setCachedData(key, data) {
+            try {
+                localStorage.setItem(getCacheKey(key), JSON.stringify({
+                    timestamp: Date.now(),
+                    data,
+                }));
+            } catch (error) {
+                console.error(error);
+            }
+        }
+
         async function fetchJson(url) {
             const response = await fetch(url);
             if (!response.ok) {
                 throw new Error(`Request failed: ${response.status}`);
             }
             return response.json();
+        }
+
+        async function fetchJsonCached(url, cacheKey) {
+            const cached = getCachedData(cacheKey);
+            if (cached) {
+                return cached;
+            }
+            const data = await fetchJson(url);
+            setCachedData(cacheKey, data);
+            return data;
         }
 
         function renderPhotoCard(photo) {
@@ -689,7 +731,10 @@
                 imagesGrid.innerHTML = "";
             }
             try {
-                const data = await fetchJson(`${API_BASE}/photos?page=${currentPage}&limit=${pageSize}`);
+                const data = await fetchJsonCached(
+                    `${API_BASE}/photos?page=${currentPage}&limit=${pageSize}`,
+                    `photos-page-${currentPage}`
+                );
                 const photos = data.results || [];
                 appendPhotos(photos, imagesGrid);
                 currentPage += 1;
@@ -711,14 +756,17 @@
         async function loadCollections() {
             gallery.innerHTML = "<p>Loading collections...</p>";
             try {
-                const data = await fetchJson(`${API_BASE}/collections`);
+                const data = await fetchJsonCached(`${API_BASE}/collections`, "collections");
                 const collections = data.results || [];
                 const enrichedCollections = await Promise.all(collections.map(async (collection) => {
                     if (!collection.cover_photo_id) {
                         return { ...collection, coverPhoto: null };
                     }
                     try {
-                        const coverPhoto = await fetchJson(`${API_BASE}/photos/${collection.cover_photo_id}`);
+                        const coverPhoto = await fetchJsonCached(
+                            `${API_BASE}/photos/${collection.cover_photo_id}`,
+                            `photo-${collection.cover_photo_id}`
+                        );
                         return { ...collection, coverPhoto };
                     } catch (error) {
                         console.error(error);
@@ -754,7 +802,10 @@
             });
 
             try {
-                const data = await fetchJson(`${API_BASE}/collections/${collectionId}/photos`);
+                const data = await fetchJsonCached(
+                    `${API_BASE}/collections/${collectionId}/photos`,
+                    `collection-${collectionId}-photos`
+                );
                 const photos = data.results || [];
                 modalTitle.innerText = collectionTitle || "Collection";
                 renderPhotos(photos, modalImages);

--- a/photo.html
+++ b/photo.html
@@ -154,7 +154,7 @@
             flex-direction: column;
             align-items: flex-start;
             gap: 0.5rem;
-            margin-bottom: 2rem;
+            margin: 0 0 2.5rem;
             font-family: 'Inter', sans-serif;
             font-style: normal;
             font-size: 0.9rem;
@@ -187,6 +187,7 @@
         .summary-note {
             font-size: 0.8rem;
             opacity: 0.6;
+            letter-spacing: 0.2px;
         }
 
         .page-links {
@@ -731,7 +732,6 @@
     <div class="page-content">
         <h1 class="fade-in">Photography</h1>
         <p class="page-subtitle fade-in fade-in-delay-1">Film and digital across Latin America, the US, Europe, Africa, and wherever else I end up.</p>
-        <div class="summary-stats fade-in fade-in-delay-2" id="summary-stats"></div>
         
         <p class="section-heading fade-in">Follow me</p>
         <div class="page-links fade-in fade-in-delay-2">
@@ -740,6 +740,7 @@
             <a href="https://glass.photo/wilude" target="_blank">on Glass</a>
             <a href="https://judes.darkroom.com" target="_blank">Buy Prints</a>
         </div>
+        <div class="summary-stats fade-in fade-in-delay-3" id="summary-stats"></div>
 
         <h2 class="section-heading fade-in fade-in-delay-2">Collections</h2>
         <div class="collections-grid fade-in fade-in-delay-3" id="gallery"></div>

--- a/photo.html
+++ b/photo.html
@@ -24,6 +24,17 @@
             box-sizing: border-box;
         }
 
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            border: 0;
+        }
+
         body {
             font-family: 'Instrument Serif', serif;
             font-style: italic;
@@ -189,6 +200,26 @@
             margin-bottom: 4rem;
         }
 
+        .section-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+            flex-wrap: wrap;
+        }
+
+        .sort-select {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.9);
+            background: rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            padding: 0.5rem 0.75rem;
+        }
+
         .collection-card {
             position: relative;
             display: block;
@@ -272,6 +303,21 @@
 
         .photo-grid-item:hover img {
             transform: scale(1.05);
+        }
+
+        .photo-stats {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            display: flex;
+            gap: 0.75rem;
+            padding: 0.5rem 0.75rem;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.75rem;
+            font-weight: 300;
+            background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
         }
 
         /* Collection modal */
@@ -592,10 +638,30 @@
             <a href="https://judes.darkroom.com" target="_blank">Buy Prints</a>
         </div>
 
-        <h2 class="section-heading fade-in fade-in-delay-2">Collections</h2>
+        <div class="section-toolbar fade-in fade-in-delay-2">
+            <h2 class="section-heading">Collections</h2>
+            <label>
+                <span class="sr-only">Sort collections</span>
+                <select class="sort-select" id="collections-sort">
+                    <option value="views" selected>Sort by Views</option>
+                    <option value="downloads">Sort by Downloads</option>
+                    <option value="latest">Sort by Latest</option>
+                </select>
+            </label>
+        </div>
         <div class="collections-grid fade-in fade-in-delay-3" id="gallery"></div>
 
-        <h2 class="section-heading fade-in">All Photos</h2>
+        <div class="section-toolbar fade-in">
+            <h2 class="section-heading">All Photos</h2>
+            <label>
+                <span class="sr-only">Sort all photos</span>
+                <select class="sort-select" id="photos-sort">
+                    <option value="views" selected>Sort by Views</option>
+                    <option value="downloads">Sort by Downloads</option>
+                    <option value="latest">Sort by Latest</option>
+                </select>
+            </label>
+        </div>
         <div class="photo-grid fade-in" id="images"></div>
         <div class="photo-loader" id="photo-loader">Loading photos...</div>
     </div>
@@ -636,6 +702,8 @@
         const gallery = document.getElementById("gallery");
         const imagesGrid = document.getElementById("images");
         const photoLoader = document.getElementById("photo-loader");
+        const photosSort = document.getElementById("photos-sort");
+        const collectionsSort = document.getElementById("collections-sort");
         const modal = document.getElementById('collection-modal');
         const modalTitle = document.getElementById('collection_title');
         const modalImages = document.getElementById('collection_images');
@@ -650,6 +718,8 @@
         const pageSize = 24;
         let isLoadingPhotos = false;
         let hasMorePhotos = true;
+        let activePhotoSort = "views";
+        let activeCollectionSort = "views";
 
         function getCacheKey(key) {
             return `judes-photo-cache:${key}`;
@@ -703,11 +773,19 @@
         function renderPhotoCard(photo) {
             const imageUrl = photo.url_small || photo.url_regular;
             const alt = photo.alt_description || photo.description || "Photo";
+            const likes = photo.likes ?? 0;
+            const views = photo.views ?? 0;
+            const downloads = photo.downloads ?? 0;
             return `
                 <div class="photo-grid-item">
                     <a href="${photo.url_regular}" data-src="${photo.url_regular}" data-alt="${alt}" data-user-name="${photo.user_name}" data-user-profile="${photo.user_profile}" data-attribution-url="${photo.attribution_url}">
                         <img src="${imageUrl}" alt="${alt}" loading="lazy" decoding="async">
                     </a>
+                    <div class="photo-stats">
+                        <span>❤ ${likes}</span>
+                        <span>👁 ${views}</span>
+                        <span>⬇ ${downloads}</span>
+                    </div>
                 </div>`;
         }
 
@@ -732,8 +810,8 @@
             }
             try {
                 const data = await fetchJsonCached(
-                    `${API_BASE}/photos?page=${currentPage}&limit=${pageSize}`,
-                    `photos-page-${currentPage}`
+                    `${API_BASE}/photos?page=${currentPage}&limit=${pageSize}&sort=${activePhotoSort}`,
+                    `photos-page-${activePhotoSort}-${currentPage}`
                 );
                 const photos = data.results || [];
                 appendPhotos(photos, imagesGrid);
@@ -756,7 +834,10 @@
         async function loadCollections() {
             gallery.innerHTML = "<p>Loading collections...</p>";
             try {
-                const data = await fetchJsonCached(`${API_BASE}/collections`, "collections");
+                const data = await fetchJsonCached(
+                    `${API_BASE}/collections?sort=${activeCollectionSort}`,
+                    `collections-${activeCollectionSort}`
+                );
                 const collections = data.results || [];
                 const enrichedCollections = await Promise.all(collections.map(async (collection) => {
                     if (!collection.cover_photo_id) {
@@ -803,8 +884,8 @@
 
             try {
                 const data = await fetchJsonCached(
-                    `${API_BASE}/collections/${collectionId}/photos`,
-                    `collection-${collectionId}-photos`
+                    `${API_BASE}/collections/${collectionId}/photos?sort=${activeCollectionSort}`,
+                    `collection-${collectionId}-photos-${activeCollectionSort}`
                 );
                 const photos = data.results || [];
                 modalTitle.innerText = collectionTitle || "Collection";
@@ -909,6 +990,16 @@
         }, { threshold: 0.1 });
 
         document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+
+        photosSort.addEventListener('change', () => {
+            activePhotoSort = photosSort.value;
+            loadAllPhotos({ reset: true });
+        });
+
+        collectionsSort.addEventListener('change', () => {
+            activeCollectionSort = collectionsSort.value;
+            loadCollections();
+        });
 
         const infiniteObserver = new IntersectionObserver((entries) => {
             entries.forEach(entry => {

--- a/photo.html
+++ b/photo.html
@@ -363,6 +363,12 @@
             letter-spacing: 0.2px;
         }
 
+        .photo-stat svg {
+            width: 0.85rem;
+            height: 0.85rem;
+            display: block;
+        }
+
         /* Collection modal */
         .modal-overlay {
             display: none;
@@ -827,9 +833,26 @@
                         <img src="${imageUrl}" alt="${alt}" loading="lazy" decoding="async">
                     </a>
                     <div class="photo-stats">
-                        <span class="photo-stat">Likes ${likes}</span>
-                        <span class="photo-stat">Views ${views}</span>
-                        <span class="photo-stat">Downloads ${downloads}</span>
+                        <span class="photo-stat" aria-label="Likes ${likes}">
+                            <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                                <path fill="#FF6B6B" d="M12 21s-7.2-4.7-9.5-9C.7 8.4 2 5.3 4.7 4.4c2.1-.7 4.2.1 5.6 1.8C11.7 4.5 13.8 3.7 16 4.4 18.7 5.3 20 8.4 19.5 12c-2.3 4.3-9.5 9-9.5 9z"/>
+                            </svg>
+                            ${likes}
+                        </span>
+                        <span class="photo-stat" aria-label="Views ${views}">
+                            <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                                <path fill="#7BDFF2" d="M12 5C6.5 5 2 9.1 1 12c1 2.9 5.5 7 11 7s10-4.1 11-7c-1-2.9-5.5-7-11-7zm0 11a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/>
+                                <circle fill="#7BDFF2" cx="12" cy="12" r="2.2"/>
+                            </svg>
+                            ${views}
+                        </span>
+                        <span class="photo-stat" aria-label="Downloads ${downloads}">
+                            <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                                <path fill="#B6E388" d="M12 3a1 1 0 0 1 1 1v9.2l2.6-2.6a1 1 0 1 1 1.4 1.4l-4.3 4.3a1 1 0 0 1-1.4 0L7 12a1 1 0 1 1 1.4-1.4L11 13.2V4a1 1 0 0 1 1-1z"/>
+                                <path fill="#B6E388" d="M5 19a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H6a1 1 0 0 1-1-1z"/>
+                            </svg>
+                            ${downloads}
+                        </span>
                     </div>
                 </div>`;
         }

--- a/photo.html
+++ b/photo.html
@@ -149,6 +149,34 @@
             line-height: 1.6;
         }
 
+        .summary-stats {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-bottom: 3rem;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.75);
+        }
+
+        .summary-stat {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.4rem 0.75rem;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }
+
+        .summary-stat svg {
+            width: 0.9rem;
+            height: 0.9rem;
+            display: block;
+        }
+
         .page-links {
             display: flex;
             flex-wrap: wrap;
@@ -333,6 +361,19 @@
 
         .photo-grid-item:hover img {
             transform: scale(1.05);
+        }
+
+        .photo-grid.animating .photo-grid-item {
+            opacity: 0;
+            transform: translateY(12px);
+            animation: photoGridIn 0.4s ease forwards;
+        }
+
+        @keyframes photoGridIn {
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
         }
 
         .photo-stats {
@@ -678,6 +719,7 @@
     <div class="page-content">
         <h1 class="fade-in">Photography</h1>
         <p class="page-subtitle fade-in fade-in-delay-1">Film and digital across Latin America, the US, Europe, Africa, and wherever else I end up.</p>
+        <div class="summary-stats fade-in fade-in-delay-2" id="summary-stats"></div>
         
         <p class="section-heading fade-in">Follow me</p>
         <div class="page-links fade-in fade-in-delay-2">
@@ -755,6 +797,7 @@
         const photoLoader = document.getElementById("photo-loader");
         const photosSort = document.getElementById("photos-sort");
         const collectionsSort = document.getElementById("collections-sort");
+        const summaryStats = document.getElementById("summary-stats");
         const modal = document.getElementById('collection-modal');
         const modalTitle = document.getElementById('collection_title');
         const modalImages = document.getElementById('collection_images');
@@ -771,6 +814,7 @@
         let hasMorePhotos = true;
         let activePhotoSort = "views";
         let activeCollectionSort = "views";
+        const numberFormatter = new Intl.NumberFormat();
 
         function getCacheKey(key) {
             return `judes-photo-cache:${key}`;
@@ -824,9 +868,9 @@
         function renderPhotoCard(photo) {
             const imageUrl = photo.url_small || photo.url_regular;
             const alt = photo.alt_description || photo.description || "Photo";
-            const likes = photo.likes ?? 0;
-            const views = photo.views ?? 0;
-            const downloads = photo.downloads ?? 0;
+            const likes = numberFormatter.format(photo.likes ?? 0);
+            const views = numberFormatter.format(photo.views ?? 0);
+            const downloads = numberFormatter.format(photo.downloads ?? 0);
             return `
                 <div class="photo-grid-item">
                     <a href="${photo.url_regular}" data-src="${photo.url_regular}" data-alt="${alt}" data-user-name="${photo.user_name}" data-user-profile="${photo.user_profile}" data-attribution-url="${photo.attribution_url}">
@@ -865,6 +909,83 @@
             container.insertAdjacentHTML('beforeend', photos.map(renderPhotoCard).join(""));
         }
 
+        function renderSummaryStats(totals) {
+            summaryStats.innerHTML = `
+                <span class="summary-stat" aria-label="Total likes ${totals.likes}">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                        <path fill="#FF6B6B" d="M12 21s-7.2-4.7-9.5-9C.7 8.4 2 5.3 4.7 4.4c2.1-.7 4.2.1 5.6 1.8C11.7 4.5 13.8 3.7 16 4.4 18.7 5.3 20 8.4 19.5 12c-2.3 4.3-9.5 9-9.5 9z"/>
+                    </svg>
+                    ${totals.likes}
+                </span>
+                <span class="summary-stat" aria-label="Total views ${totals.views}">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                        <path fill="#7BDFF2" d="M12 5C6.5 5 2 9.1 1 12c1 2.9 5.5 7 11 7s10-4.1 11-7c-1-2.9-5.5-7-11-7zm0 11a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"/>
+                        <circle fill="#7BDFF2" cx="12" cy="12" r="2.2"/>
+                    </svg>
+                    ${totals.views}
+                </span>
+                <span class="summary-stat" aria-label="Total downloads ${totals.downloads}">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                        <path fill="#B6E388" d="M12 3a1 1 0 0 1 1 1v9.2l2.6-2.6a1 1 0 1 1 1.4 1.4l-4.3 4.3a1 1 0 0 1-1.4 0L7 12a1 1 0 1 1 1.4-1.4L11 13.2V4a1 1 0 0 1 1-1z"/>
+                        <path fill="#B6E388" d="M5 19a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H6a1 1 0 0 1-1-1z"/>
+                    </svg>
+                    ${totals.downloads}
+                </span>
+            `;
+        }
+
+        async function loadSummaryStats() {
+            summaryStats.innerHTML = "<span class=\"summary-stat\">Loading stats...</span>";
+            try {
+                const cacheKey = "summary-stats";
+                const cached = getCachedData(cacheKey);
+                if (cached) {
+                    renderSummaryStats(cached);
+                    return;
+                }
+                let page = 1;
+                let hasMore = true;
+                let totalLikes = 0;
+                let totalViews = 0;
+                let totalDownloads = 0;
+
+                while (hasMore) {
+                    const data = await fetchJson(`${API_BASE}/photos?page=${page}&limit=${pageSize}`);
+                    const photos = data.results || [];
+                    photos.forEach((photo) => {
+                        totalLikes += photo.likes ?? 0;
+                        totalViews += photo.views ?? 0;
+                        totalDownloads += photo.downloads ?? 0;
+                    });
+                    if (photos.length < pageSize) {
+                        hasMore = false;
+                    } else {
+                        page += 1;
+                    }
+                }
+
+                const totals = {
+                    likes: numberFormatter.format(totalLikes),
+                    views: numberFormatter.format(totalViews),
+                    downloads: numberFormatter.format(totalDownloads),
+                };
+                setCachedData(cacheKey, totals);
+                renderSummaryStats(totals);
+            } catch (error) {
+                summaryStats.innerHTML = "<span class=\"summary-stat\">Unable to load stats.</span>";
+                console.error(error);
+            }
+        }
+
+        function animateGrid(container) {
+            container.classList.remove('animating');
+            void container.offsetWidth;
+            container.classList.add('animating');
+            setTimeout(() => {
+                container.classList.remove('animating');
+            }, 500);
+        }
+
         async function loadAllPhotos({ reset = false } = {}) {
             if (isLoadingPhotos || (!hasMorePhotos && !reset)) {
                 return;
@@ -875,6 +996,7 @@
                 currentPage = 1;
                 hasMorePhotos = true;
                 imagesGrid.innerHTML = "";
+                animateGrid(imagesGrid);
             }
             try {
                 const data = await fetchJsonCached(
@@ -932,6 +1054,7 @@
                             <div class="collection-title">${title}</div>
                         </a>`;
                 }).join("");
+                animateGrid(gallery);
             } catch (error) {
                 gallery.innerHTML = "<p>Unable to load collections right now.</p>";
                 console.error(error);
@@ -958,6 +1081,7 @@
                 const photos = data.results || [];
                 modalTitle.innerText = collectionTitle || "Collection";
                 renderPhotos(photos, modalImages);
+                animateGrid(modalImages);
             } catch (error) {
                 modalTitle.innerText = collectionTitle || "Collection";
                 modalImages.innerHTML = "<p>Unable to load collection photos right now.</p>";
@@ -1083,6 +1207,7 @@
         infiniteObserver.observe(photoLoader);
 
         loadAllPhotos({ reset: true });
+        loadSummaryStats();
         loadCollections();
     </script>
 </body>

--- a/photo.html
+++ b/photo.html
@@ -433,6 +433,24 @@
             gap: 1rem;
         }
 
+        .lightbox-attribution {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.85rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.7);
+            text-align: center;
+        }
+
+        .lightbox-attribution a {
+            color: rgba(255, 255, 255, 0.85);
+            text-decoration: none;
+        }
+
+        .lightbox-attribution a:hover {
+            opacity: 0.7;
+        }
+
         .lightbox-btn {
             color: rgba(255, 255, 255, 0.8);
             text-decoration: none;
@@ -587,6 +605,7 @@
                 <a id="lightbox-download" class="lightbox-btn" href="" download>Download</a>
                 <button class="lightbox-btn" id="lightbox-close">Close</button>
             </div>
+            <p class="lightbox-attribution" id="lightbox-attribution"></p>
         </div>
     </div>
 
@@ -601,84 +620,90 @@
     </div>
 
     <script>
-        // All photos grid
-        var html = "";
-        for (var i = 0; i < 30; i++) {
-            html += `
-            <div class="photo-grid-item">
-                <a href="/assets/images/home/image_${i}.jpg">
-                    <img src="/assets/images/home/image_${i}.jpg" alt="Image ${i}" loading="lazy" decoding="async">
-                </a>
-            </div>`;
-        }
-        document.getElementById("images").innerHTML = html;
-
-        // Collections
-        const projects = [
-            {
-                title: "Rice Farm Horses",
-                cover: "rice_horses/img_2",
-                desc: "",
-                album: { folder: "rice_horses", photo_prefix: "img_", photo_index: 15 },
-            },
-            {
-                title: "PNS Car Shoot: 1/3/24",
-                cover: "wrx_shoot/img-1",
-                desc: "",
-                album: { folder: "wrx_shoot", photo_prefix: "img-", photo_index: 12 },
-            },
-            {
-                title: "Rocket",
-                cover: "rocket/img-5",
-                desc: "",
-                album: { folder: "rocket", photo_prefix: "img-", photo_index: 6 },
-            },
-            {
-                title: "Ecuador 23",
-                cover: "ecuador/img-24",
-                desc: "",
-                album: { folder: "ecuador", photo_prefix: "img-", photo_index: 27 },
-            },
-            {
-                title: "Real Estate Example",
-                cover: "re/img_0",
-                desc: "",
-                album: { folder: "re", photo_prefix: "img_", photo_index: 52 },
-            },
-        ];
-
-        // Render collection cards
-        var projectHtml = "";
-        for (var i = 0; i < projects.length; i++) {
-            projectHtml += `
-            <a href="#" class="collection-card" data-project="${i}">
-                <img src="/assets/images/${projects[i].cover}.jpg" alt="${projects[i].title}" loading="lazy" decoding="async">
-                <div class="collection-title">${projects[i].title}</div>
-            </a>`;
-        }
-        document.getElementById("gallery").innerHTML = projectHtml;
-
-        // Modal logic
+        const API_BASE = "https://judes-club-photos.hi-eab.workers.dev";
+        const gallery = document.getElementById("gallery");
+        const imagesGrid = document.getElementById("images");
         const modal = document.getElementById('collection-modal');
         const modalTitle = document.getElementById('collection_title');
         const modalImages = document.getElementById('collection_images');
         const modalClose = document.getElementById('modal-close');
 
-        function openCollection(index) {
-            const p = projects[index];
-            modalTitle.innerText = p.title;
+        const lightbox = document.getElementById('lightbox');
+        const lightboxImg = document.getElementById('lightbox-img');
+        const lightboxDownload = document.getElementById('lightbox-download');
+        const lightboxCloseBtn = document.getElementById('lightbox-close');
+        const lightboxAttribution = document.getElementById('lightbox-attribution');
 
-            var photosHtml = "";
-            for (var j = 0; j < p.album.photo_index; j++) {
-                photosHtml += `
+        async function fetchJson(url) {
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error(`Request failed: ${response.status}`);
+            }
+            return response.json();
+        }
+
+        function renderPhotoCard(photo) {
+            const imageUrl = photo.url_small || photo.url_regular;
+            const alt = photo.alt_description || photo.description || "Photo";
+            return `
                 <div class="photo-grid-item">
-                    <a href="/assets/images/${p.album.folder}/${p.album.photo_prefix}${j}.jpg">
-                        <img src="/assets/images/${p.album.folder}/${p.album.photo_prefix}${j}.jpg" alt="Image ${j}" loading="lazy" decoding="async">
+                    <a href="${photo.url_regular}" data-src="${photo.url_regular}" data-alt="${alt}" data-user-name="${photo.user_name}" data-user-profile="${photo.user_profile}" data-attribution-url="${photo.attribution_url}">
+                        <img src="${imageUrl}" alt="${alt}" loading="lazy" decoding="async">
                     </a>
                 </div>`;
-            }
-            modalImages.innerHTML = photosHtml;
+        }
 
+        function renderPhotos(photos, container) {
+            container.innerHTML = photos.map(renderPhotoCard).join("");
+        }
+
+        async function loadAllPhotos() {
+            imagesGrid.innerHTML = "<p>Loading photos...</p>";
+            try {
+                const data = await fetchJson(`${API_BASE}/photos`);
+                renderPhotos(data.results || [], imagesGrid);
+            } catch (error) {
+                imagesGrid.innerHTML = "<p>Unable to load photos right now.</p>";
+                console.error(error);
+            }
+        }
+
+        async function loadCollections() {
+            gallery.innerHTML = "<p>Loading collections...</p>";
+            try {
+                const data = await fetchJson(`${API_BASE}/collections`);
+                const collections = data.results || [];
+                const enrichedCollections = await Promise.all(collections.map(async (collection) => {
+                    if (!collection.cover_photo_id) {
+                        return { ...collection, coverPhoto: null };
+                    }
+                    try {
+                        const coverPhoto = await fetchJson(`${API_BASE}/photos/${collection.cover_photo_id}`);
+                        return { ...collection, coverPhoto };
+                    } catch (error) {
+                        console.error(error);
+                        return { ...collection, coverPhoto: null };
+                    }
+                }));
+
+                gallery.innerHTML = enrichedCollections.map((collection) => {
+                    const coverUrl = collection.coverPhoto?.url_regular || "";
+                    const title = collection.title || "Collection";
+                    return `
+                        <a href="#" class="collection-card" data-collection-id="${collection.id}" data-collection-title="${title}">
+                            ${coverUrl ? `<img src="${coverUrl}" alt="${title}" loading="lazy" decoding="async">` : ""}
+                            <div class="collection-title">${title}</div>
+                        </a>`;
+                }).join("");
+            } catch (error) {
+                gallery.innerHTML = "<p>Unable to load collections right now.</p>";
+                console.error(error);
+            }
+        }
+
+        async function openCollection(collectionId, collectionTitle) {
+            modalTitle.innerText = collectionTitle || "Loading...";
+            modalImages.innerHTML = "<p>Loading photos...</p>";
             modal.style.display = 'block';
             modal.scrollTop = 0;
             requestAnimationFrame(() => {
@@ -687,6 +712,17 @@
                     document.body.style.overflow = 'hidden';
                 });
             });
+
+            try {
+                const data = await fetchJson(`${API_BASE}/collections/${collectionId}/photos`);
+                const photos = data.results || [];
+                modalTitle.innerText = collectionTitle || "Collection";
+                renderPhotos(photos, modalImages);
+            } catch (error) {
+                modalTitle.innerText = collectionTitle || "Collection";
+                modalImages.innerHTML = "<p>Unable to load collection photos right now.</p>";
+                console.error(error);
+            }
         }
 
         function closeModal() {
@@ -704,7 +740,7 @@
             const card = e.target.closest('.collection-card');
             if (card) {
                 e.preventDefault();
-                openCollection(Number(card.dataset.project));
+                openCollection(card.dataset.collectionId, card.dataset.collectionTitle);
             }
         });
 
@@ -719,14 +755,14 @@
         });
 
         // Image lightbox
-        const lightbox = document.getElementById('lightbox');
-        const lightboxImg = document.getElementById('lightbox-img');
-        const lightboxDownload = document.getElementById('lightbox-download');
-        const lightboxCloseBtn = document.getElementById('lightbox-close');
-
-        function openLightbox(src) {
-            lightboxImg.src = src;
-            lightboxDownload.href = src;
+        function openLightbox(data) {
+            lightboxImg.src = data.src;
+            lightboxImg.alt = data.alt || "Photo";
+            lightboxDownload.href = data.src;
+            lightboxAttribution.innerHTML = `
+                Photo by <a href="${data.userProfile}" target="_blank" rel="noopener">${data.userName}</a>
+                on <a href="${data.attributionUrl}" target="_blank" rel="noopener">Unsplash</a>
+            `;
             lightbox.style.display = 'flex';
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
@@ -744,6 +780,7 @@
                 lightbox.style.display = 'none';
                 document.body.style.overflow = modal.classList.contains('active') ? 'hidden' : '';
                 lightboxImg.src = '';
+                lightboxAttribution.innerHTML = '';
             }, 400);
         }
 
@@ -751,7 +788,13 @@
             const item = e.target.closest('.photo-grid-item a');
             if (item) {
                 e.preventDefault();
-                openLightbox(item.href);
+                openLightbox({
+                    src: item.dataset.src || item.href,
+                    alt: item.dataset.alt,
+                    userName: item.dataset.userName,
+                    userProfile: item.dataset.userProfile,
+                    attributionUrl: item.dataset.attributionUrl,
+                });
             }
         });
 
@@ -775,6 +818,9 @@
         }, { threshold: 0.1 });
 
         document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+
+        loadAllPhotos();
+        loadCollections();
     </script>
 </body>
 </html>

--- a/photo.html
+++ b/photo.html
@@ -195,7 +195,7 @@
             text-decoration: none;
             color: white;
             overflow: hidden;
-            aspect-ratio: 16 / 10;
+            aspect-ratio: 16 / 6;
             background: rgba(255, 255, 255, 0.04);
             border: 1px solid rgba(255, 255, 255, 0.08);
             transition: border-color 0.3s, transform 0.3s;
@@ -237,6 +237,16 @@
             grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
             gap: 0.75rem;
             margin-bottom: 4rem;
+        }
+
+        .photo-loader {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.9rem;
+            font-weight: 300;
+            opacity: 0.6;
+            text-align: center;
+            padding: 1.5rem 0 3rem;
         }
 
         .photo-grid-item {
@@ -539,7 +549,7 @@
             }
 
             .collection-card {
-                aspect-ratio: 5 / 2;
+                aspect-ratio: 5 / 1.6;
             }
 
             .photo-grid {
@@ -587,6 +597,7 @@
 
         <h2 class="section-heading fade-in">All Photos</h2>
         <div class="photo-grid fade-in" id="images"></div>
+        <div class="photo-loader" id="photo-loader">Loading photos...</div>
     </div>
 
     <footer class="footer">
@@ -623,6 +634,7 @@
         const API_BASE = "https://judes-club-photos.hi-eab.workers.dev";
         const gallery = document.getElementById("gallery");
         const imagesGrid = document.getElementById("images");
+        const photoLoader = document.getElementById("photo-loader");
         const modal = document.getElementById('collection-modal');
         const modalTitle = document.getElementById('collection_title');
         const modalImages = document.getElementById('collection_images');
@@ -633,6 +645,10 @@
         const lightboxDownload = document.getElementById('lightbox-download');
         const lightboxCloseBtn = document.getElementById('lightbox-close');
         const lightboxAttribution = document.getElementById('lightbox-attribution');
+        let currentPage = 1;
+        const pageSize = 24;
+        let isLoadingPhotos = false;
+        let hasMorePhotos = true;
 
         async function fetchJson(url) {
             const response = await fetch(url);
@@ -657,14 +673,38 @@
             container.innerHTML = photos.map(renderPhotoCard).join("");
         }
 
-        async function loadAllPhotos() {
-            imagesGrid.innerHTML = "<p>Loading photos...</p>";
+        function appendPhotos(photos, container) {
+            container.insertAdjacentHTML('beforeend', photos.map(renderPhotoCard).join(""));
+        }
+
+        async function loadAllPhotos({ reset = false } = {}) {
+            if (isLoadingPhotos || (!hasMorePhotos && !reset)) {
+                return;
+            }
+            isLoadingPhotos = true;
+            photoLoader.textContent = "Loading photos...";
+            if (reset) {
+                currentPage = 1;
+                hasMorePhotos = true;
+                imagesGrid.innerHTML = "";
+            }
             try {
-                const data = await fetchJson(`${API_BASE}/photos`);
-                renderPhotos(data.results || [], imagesGrid);
+                const data = await fetchJson(`${API_BASE}/photos?page=${currentPage}&limit=${pageSize}`);
+                const photos = data.results || [];
+                appendPhotos(photos, imagesGrid);
+                currentPage += 1;
+                if (photos.length < pageSize) {
+                    hasMorePhotos = false;
+                    photoLoader.textContent = "You're all caught up.";
+                }
             } catch (error) {
-                imagesGrid.innerHTML = "<p>Unable to load photos right now.</p>";
+                if (!imagesGrid.innerHTML) {
+                    imagesGrid.innerHTML = "<p>Unable to load photos right now.</p>";
+                }
+                photoLoader.textContent = "Unable to load more photos.";
                 console.error(error);
+            } finally {
+                isLoadingPhotos = false;
             }
         }
 
@@ -819,7 +859,17 @@
 
         document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
 
-        loadAllPhotos();
+        const infiniteObserver = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    loadAllPhotos();
+                }
+            });
+        }, { rootMargin: '300px' });
+
+        infiniteObserver.observe(photoLoader);
+
+        loadAllPhotos({ reset: true });
         loadCollections();
     </script>
 </body>

--- a/photo.html
+++ b/photo.html
@@ -376,19 +376,6 @@
             transform: scale(1.05);
         }
 
-        .photo-grid.animating .photo-grid-item {
-            opacity: 0;
-            transform: translateY(12px);
-            animation: photoGridIn 0.4s ease forwards;
-        }
-
-        @keyframes photoGridIn {
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
         .photo-stats {
             position: absolute;
             bottom: 0;
@@ -752,6 +739,7 @@
                 <span class="sr-only">Sort all photos</span>
                 <select class="sort-select" id="photos-sort">
                     <option value="views">Sort by Views</option>
+                    <option value="likes">Sort by Likes</option>
                     <option value="downloads">Sort by Downloads</option>
                     <option value="latest">Sort by Latest</option>
                 </select>
@@ -905,6 +893,16 @@
             container.innerHTML = photos.map(renderPhotoCard).join("");
         }
 
+        function animateSortedGrid(container) {
+            const items = container.querySelectorAll('.photo-grid-item');
+            items.forEach((item, index) => {
+                item.style.opacity = '0';
+                item.style.transform = 'translateY(12px)';
+                item.style.animation = `modalItemIn 0.4s ease forwards`;
+                item.style.animationDelay = `${Math.min(index * 0.05, 0.4)}s`;
+            });
+        }
+
         function appendPhotos(photos, container) {
             container.insertAdjacentHTML('beforeend', photos.map(renderPhotoCard).join(""));
         }
@@ -1008,6 +1006,9 @@
                 );
                 const photos = data.results || [];
                 appendPhotos(photos, imagesGrid);
+                if (reset) {
+                    animateSortedGrid(imagesGrid);
+                }
                 currentPage += 1;
                 if (photos.length < pageSize) {
                     hasMorePhotos = false;


### PR DESCRIPTION
### Motivation
- Replace the existing local/static photography assets with dynamic, API-driven collections and photo grids so the page shows up-to-date photos served from the external photo service.
- Ensure required Unsplash attribution is displayed when an image is viewed in the lightbox.
- Provide basic loading and error states for the network requests so the UI behaves reasonably when the API is slow or unavailable.

### Description
- Replaced the static local image grid and `projects` array with an API integration using `API_BASE = "https://judes-club-photos.hi-eab.workers.dev"` and a helper `fetchJson` function in `photo.html`.
- Added `renderPhotoCard`, `renderPhotos`, `loadAllPhotos`, and `loadCollections` to fetch and render `GET /photos` and `GET /collections`, and fetch collection cover photos via `GET /photos/:id` for gallery cards.
- Updated collection modal to fetch photos from `GET /collections/:id/photos` and render them dynamically, and wired collection card clicks to use `data-collection-id` and `data-collection-title`.
- Implemented a lightbox attribution block and styles (`.lightbox-attribution`) and updated `openLightbox`/`closeLightbox` to populate photographer attribution links (`user_name`, `user_profile`, `attribution_url`) per Unsplash requirements.
- Added simple loading/error messages for photo and collection fetches and removed the old static markup that referenced local `/assets/images/*` files.

### Testing
- Started a local static server and used a Playwright script to open `http://localhost:8000/photo.html` and capture a screenshot, which completed successfully and produced `artifacts/photo-page.png` showing the updated page rendering without fatal runtime errors.
- Verified that the page attempts API calls and renders loading placeholders and that the lightbox displays attribution when opening an image via the UI during the automated run.
- No unit tests were added or run as this change is a static front-end integration in `photo.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c2026d5cc8330b66a46cf1ee547b9)