### PR TITLE
Add rotating quote to Links footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,27 +421,21 @@
         }
 
         .quote-rotator {
-            position: absolute;
-            top: 50%;
-            left: 0;
-            right: 0;
-            transform: translateY(-50%);
             display: flex;
-            justify-content: center;
-            text-align: center;
-            max-width: min(560px, 80vw);
-            padding: 0 1rem;
+            justify-content: flex-start;
+            text-align: left;
+            max-width: 520px;
+            padding: 0;
             font-family: 'Instrument Serif', serif;
             font-style: italic;
             color: white;
             text-shadow: 0 1px 12px rgba(0, 0, 0, 0.5);
-            z-index: 1;
         }
 
         .quote-rotator-inner {
             display: flex;
             flex-direction: column;
-            align-items: center;
+            align-items: flex-start;
             gap: 0.35rem;
             transition: opacity 0.5s ease, transform 0.5s ease, filter 0.5s ease;
         }
@@ -1071,19 +1065,19 @@
     <section class="section section-5">
         <div class="footer-content">
             <h1 class="fade-in" style="font-size: 2rem; font-weight: 400; font-style: normal;">Links</h1>
-            <div class="social-links fade-in fade-in-delay-1">
+            <div class="quote-rotator fade-in fade-in-delay-1" id="quote-rotator" aria-live="polite">
+                <div class="quote-rotator-inner">
+                    <span class="quote-text" id="quote-text">“Stay hungry, stay foolish.”</span>
+                    <span class="quote-author" id="quote-author">— Steve Jobs</span>
+                </div>
+            </div>
+            <div class="social-links fade-in fade-in-delay-2">
                 <a href="https://github.com/alechash" target="_blank">GitHub</a>
                 <a href="https://instagram.com/wil.tography" target="_blank">Instagram</a>
                 <a href="https://x.com/alechash" target="_blank">X</a>
             </div>
-            <div class="footer-bottom fade-in fade-in-delay-2">
+            <div class="footer-bottom fade-in fade-in-delay-3">
                 &copy; 2026 Alec Jude Wilson
-            </div>
-        </div>
-        <div class="quote-rotator fade-in" id="quote-rotator" aria-live="polite">
-            <div class="quote-rotator-inner">
-                <span class="quote-text" id="quote-text">“Stay hungry, stay foolish.”</span>
-                <span class="quote-author" id="quote-author">— Steve Jobs</span>
             </div>
         </div>
         <span class="photo-caption">The Sky, Earth</span>

--- a/index.html
+++ b/index.html
@@ -423,8 +423,9 @@
         .quote-rotator {
             position: absolute;
             top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
+            left: 0;
+            right: 0;
+            transform: translateY(-50%);
             display: flex;
             justify-content: center;
             text-align: center;

--- a/index.html
+++ b/index.html
@@ -420,6 +420,40 @@
             color: white;
         }
 
+        .quote-rotator {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            gap: 0.35rem;
+            margin: 1.25rem auto 2rem;
+            max-width: 520px;
+            padding: 0 1rem;
+            font-family: 'Instrument Serif', serif;
+            font-style: italic;
+            text-shadow: 0 1px 12px rgba(0, 0, 0, 0.5);
+            transition: opacity 0.4s ease, transform 0.4s ease;
+        }
+
+        .quote-rotator.is-fading {
+            opacity: 0;
+            transform: translateY(6px);
+        }
+
+        .quote-rotator .quote-text {
+            font-size: 1.2rem;
+            opacity: 0.92;
+        }
+
+        .quote-rotator .quote-author {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.8rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            opacity: 0.6;
+        }
+
         .social-links {
             display: flex;
             flex-wrap: wrap;
@@ -895,6 +929,16 @@
             .contact-email {
                 margin-top: 1rem;
             }
+
+            .quote-rotator {
+                margin-bottom: 1.5rem;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .quote-rotator {
+                transition: none;
+            }
         }
     </style>
 </head>
@@ -1015,12 +1059,16 @@
     <section class="section section-5">
         <div class="footer-content">
             <h1 class="fade-in" style="font-size: 2rem; font-weight: 400; font-style: normal;">Links</h1>
-            <div class="social-links fade-in fade-in-delay-1">
+            <div class="quote-rotator fade-in fade-in-delay-1" id="quote-rotator" aria-live="polite">
+                <span class="quote-text" id="quote-text">“Stay curious. Stay kind. Stay building.”</span>
+                <span class="quote-author" id="quote-author">— Alec Jude Wilson</span>
+            </div>
+            <div class="social-links fade-in fade-in-delay-2">
                 <a href="https://github.com/alechash" target="_blank">GitHub</a>
                 <a href="https://instagram.com/wil.tography" target="_blank">Instagram</a>
                 <a href="https://x.com/alechash" target="_blank">X</a>
             </div>
-            <div class="footer-bottom fade-in fade-in-delay-2">
+            <div class="footer-bottom fade-in fade-in-delay-3">
                 &copy; 2026 Alec Jude Wilson
             </div>
         </div>
@@ -1240,6 +1288,42 @@
             btn.textContent = 'Send';
             btn.disabled = false;
         });
+
+        // Quote rotation for Links section
+        (function() {
+            const rotator = document.getElementById('quote-rotator');
+            const textEl = document.getElementById('quote-text');
+            const authorEl = document.getElementById('quote-author');
+            if (!rotator || !textEl || !authorEl) return;
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+            const quotes = [
+                { text: '“Stay curious. Stay kind. Stay building.”', author: '— Alec Jude Wilson' },
+                { text: '“Make the ordinary feel cinematic.”', author: '— A.J.W.' },
+                { text: '“Ship, learn, repeat.”', author: '— Belayer Notes' },
+                { text: '“Light is a collaborator.”', author: '— Photo Journal' },
+            ];
+
+            let index = 0;
+
+            function setQuote(nextIndex) {
+                const quote = quotes[nextIndex];
+                textEl.textContent = quote.text;
+                authorEl.textContent = quote.author;
+            }
+
+            function rotateQuote() {
+                rotator.classList.add('is-fading');
+                setTimeout(() => {
+                    index = (index + 1) % quotes.length;
+                    setQuote(index);
+                    rotator.classList.remove('is-fading');
+                }, 400);
+            }
+
+            setQuote(index);
+            setInterval(rotateQuote, 7000);
+        })();
 
         // Section navigation — transform-based, no scrolling
         (function() {

--- a/index.html
+++ b/index.html
@@ -432,6 +432,7 @@
             padding: 0 1rem;
             font-family: 'Instrument Serif', serif;
             font-style: italic;
+            color: white;
             text-shadow: 0 1px 12px rgba(0, 0, 0, 0.5);
             z-index: 1;
         }

--- a/index.html
+++ b/index.html
@@ -427,7 +427,8 @@
             max-width: 520px;
             padding: 0;
             font-family: 'Instrument Serif', serif;
-            font-style: italic;
+            margin-top: 1.5rem;
+            margin-bottom: 1rem;
             color: white;
             text-shadow: 0 1px 12px rgba(0, 0, 0, 0.5);
         }

--- a/index.html
+++ b/index.html
@@ -421,35 +421,45 @@
         }
 
         .quote-rotator {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
             display: flex;
-            flex-direction: column;
-            align-items: center;
+            justify-content: center;
             text-align: center;
-            gap: 0.35rem;
-            margin: 1.25rem auto 2rem;
-            max-width: 520px;
+            max-width: min(560px, 80vw);
             padding: 0 1rem;
             font-family: 'Instrument Serif', serif;
             font-style: italic;
             text-shadow: 0 1px 12px rgba(0, 0, 0, 0.5);
-            transition: opacity 0.4s ease, transform 0.4s ease;
+            z-index: 1;
         }
 
-        .quote-rotator.is-fading {
+        .quote-rotator-inner {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.35rem;
+            transition: opacity 0.5s ease, transform 0.5s ease, filter 0.5s ease;
+        }
+
+        .quote-rotator.is-fading .quote-rotator-inner {
             opacity: 0;
-            transform: translateY(6px);
+            transform: translateY(8px) scale(0.98);
+            filter: blur(2px);
         }
 
         .quote-rotator .quote-text {
-            font-size: 1.2rem;
+            font-size: 1.25rem;
             opacity: 0.92;
         }
 
         .quote-rotator .quote-author {
             font-family: 'Inter', sans-serif;
             font-style: normal;
-            font-size: 0.8rem;
-            letter-spacing: 1px;
+            font-size: 0.78rem;
+            letter-spacing: 1.4px;
             text-transform: uppercase;
             opacity: 0.6;
         }
@@ -931,12 +941,12 @@
             }
 
             .quote-rotator {
-                margin-bottom: 1.5rem;
+                max-width: 85vw;
             }
         }
 
         @media (prefers-reduced-motion: reduce) {
-            .quote-rotator {
+            .quote-rotator-inner {
                 transition: none;
             }
         }
@@ -1059,17 +1069,19 @@
     <section class="section section-5">
         <div class="footer-content">
             <h1 class="fade-in" style="font-size: 2rem; font-weight: 400; font-style: normal;">Links</h1>
-            <div class="quote-rotator fade-in fade-in-delay-1" id="quote-rotator" aria-live="polite">
-                <span class="quote-text" id="quote-text">“Stay curious. Stay kind. Stay building.”</span>
-                <span class="quote-author" id="quote-author">— Alec Jude Wilson</span>
-            </div>
-            <div class="social-links fade-in fade-in-delay-2">
+            <div class="social-links fade-in fade-in-delay-1">
                 <a href="https://github.com/alechash" target="_blank">GitHub</a>
                 <a href="https://instagram.com/wil.tography" target="_blank">Instagram</a>
                 <a href="https://x.com/alechash" target="_blank">X</a>
             </div>
-            <div class="footer-bottom fade-in fade-in-delay-3">
+            <div class="footer-bottom fade-in fade-in-delay-2">
                 &copy; 2026 Alec Jude Wilson
+            </div>
+        </div>
+        <div class="quote-rotator fade-in" id="quote-rotator" aria-live="polite">
+            <div class="quote-rotator-inner">
+                <span class="quote-text" id="quote-text">“Stay hungry, stay foolish.”</span>
+                <span class="quote-author" id="quote-author">— Steve Jobs</span>
             </div>
         </div>
         <span class="photo-caption">The Sky, Earth</span>
@@ -1298,10 +1310,16 @@
             if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
             const quotes = [
-                { text: '“Stay curious. Stay kind. Stay building.”', author: '— Alec Jude Wilson' },
-                { text: '“Make the ordinary feel cinematic.”', author: '— A.J.W.' },
-                { text: '“Ship, learn, repeat.”', author: '— Belayer Notes' },
-                { text: '“Light is a collaborator.”', author: '— Photo Journal' },
+                { text: '“Stay hungry, stay foolish.”', author: '— Steve Jobs' },
+                { text: '“Simplicity is the ultimate sophistication.”', author: '— Leonardo da Vinci' },
+                { text: '“The best way out is always through.”', author: '— Robert Frost' },
+                { text: '“What we see depends mainly on what we look for.”', author: '— John Lubbock' },
+                { text: '“In the middle of difficulty lies opportunity.”', author: '— Albert Einstein' },
+                { text: '“The details are not the details. They make the design.”', author: '— Charles Eames' },
+                { text: '“It is not the mountain we conquer but ourselves.”', author: '— Edmund Hillary' },
+                { text: '“Creativity is intelligence having fun.”', author: '— Albert Einstein' },
+                { text: '“Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away.”', author: '— Antoine de Saint-Exupéry' },
+                { text: '“You miss 100% of the shots you don’t take.”', author: '— Wayne Gretzky' },
             ];
 
             let index = 0;
@@ -1318,11 +1336,11 @@
                     index = (index + 1) % quotes.length;
                     setQuote(index);
                     rotator.classList.remove('is-fading');
-                }, 400);
+                }, 500);
             }
 
             setQuote(index);
-            setInterval(rotateQuote, 7000);
+            setInterval(rotateQuote, 8000);
         })();
 
         // Section navigation — transform-based, no scrolling

--- a/index.html
+++ b/index.html
@@ -427,8 +427,8 @@
             max-width: 520px;
             padding: 0;
             font-family: 'Instrument Serif', serif;
-            margin-top: 1.5rem;
-            margin-bottom: 1rem;
+            margin-top: -1rem;
+            margin-bottom: 3rem;
             color: white;
             text-shadow: 0 1px 12px rgba(0, 0, 0, 0.5);
         }
@@ -466,7 +466,7 @@
             flex-wrap: wrap;
             gap: 1.5rem;
             margin-top: 2rem;
-            margin-bottom: 4rem;
+            margin-bottom: 3rem;
         }
 
         .social-links a {
@@ -493,6 +493,10 @@
             font-weight: 300;
             opacity: 0.5;
             text-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+        }
+
+        .footer-bottom p {
+            float: right;
         }
 
         /* Hero section */
@@ -829,6 +833,15 @@
         }
 
         @media (max-width: 768px) {
+            .footer-bottom p {
+                float: none;
+                display: block;
+            }
+
+            .footer-bottom div {
+                margin-top: 1rem;
+            }
+
             .navbar {
                 padding: 1.5rem 1.5rem;
             }
@@ -1066,19 +1079,19 @@
     <section class="section section-5">
         <div class="footer-content">
             <h1 class="fade-in" style="font-size: 2rem; font-weight: 400; font-style: normal;">Links</h1>
-            <div class="quote-rotator fade-in fade-in-delay-1" id="quote-rotator" aria-live="polite">
-                <div class="quote-rotator-inner">
-                    <span class="quote-text" id="quote-text">“Stay hungry, stay foolish.”</span>
-                    <span class="quote-author" id="quote-author">— Steve Jobs</span>
-                </div>
-            </div>
             <div class="social-links fade-in fade-in-delay-2">
                 <a href="https://github.com/alechash" target="_blank">GitHub</a>
                 <a href="https://instagram.com/wil.tography" target="_blank">Instagram</a>
-                <a href="https://x.com/alechash" target="_blank">X</a>
+                <a href="https://x.com/alechash" target="_blank">X</a><br>
             </div>
             <div class="footer-bottom fade-in fade-in-delay-3">
-                &copy; 2026 Alec Jude Wilson
+                <p>&copy; 2026 Alec Jude Wilson</p>
+                <div class="quote-rotator fade-in fade-in-delay-1" id="quote-rotator" aria-live="polite">
+                    <div class="quote-rotator-inner">
+                        <span class="quote-text" id="quote-text">“Stay hungry, stay foolish.”</span>
+                        <span class="quote-author" id="quote-author">— Steve Jobs</span>
+                    </div>
+                </div>
             </div>
         </div>
         <span class="photo-caption">The Sky, Earth</span>


### PR DESCRIPTION
### Motivation
- Add a centered, subtle quote rotation to the Links footer section to increase visual interest and surface short, branded lines without changing layout.
- Keep accessibility in mind by respecting `prefers-reduced-motion` so the rotation can be disabled for users who prefer reduced motion.

### Description
- Add a `quote-rotator` block in the Links footer (`index.html`) containing quote text and author elements with IDs `quote-text` and `quote-author` for easy updates. 
- Add CSS for `.quote-rotator` and `.quote-rotator.is-fading` to style the typographic treatment and implement a fade/translate transition, plus responsive and reduced-motion handling. 
- Adjust fade-in timing for the footer so the quote is shown between the Links title and social links. 
- Add a small JS IIFE that rotates through a curated `quotes` array on a 7s interval, applies a brief fade animation, and returns early when `prefers-reduced-motion` is set.

### Testing
- Launched a local static server (`python -m http.server`) and ran a Playwright visual check to navigate the page and capture a screenshot of the Links/footer region; the screenshot artifact was produced successfully. 
- No unit tests were added; the change is a small static HTML/CSS/JS enhancement and was validated visually via the browser automation run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c32eae8a883309aa603e9e2c4e2dc)