### PR TITLE
Add privacy policy page

### DIFF
--- a/legal/privacy-policy.html
+++ b/legal/privacy-policy.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy | Alec Jude Wilson</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+    <meta name="description" content="Privacy policy for apps by Alec Jude Wilson. We don't collect any data — everything stays on your device or in your private iCloud.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@100..900&display=swap" rel="stylesheet">
+    <style>
+        html {
+            scroll-behavior: smooth;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Instrument Serif', serif;
+            font-style: italic;
+            min-height: 100vh;
+            background: #111;
+            color: white;
+        }
+
+        .navbar {
+            position: fixed;
+            top: 0;
+            right: 0;
+            left: 0;
+            z-index: 1000;
+            padding: 1rem 1.5rem;
+            pointer-events: none;
+        }
+
+        .nav-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 0.6rem 1.5rem;
+            pointer-events: auto;
+            background: rgba(17, 17, 17, 0.7);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+        }
+
+        .logo {
+            font-size: 1.25rem;
+            font-weight: 400;
+            letter-spacing: 0.3px;
+            color: white;
+            font-family: 'Instrument Serif', serif;
+            font-style: normal;
+            text-decoration: none;
+        }
+
+        .logo-first {
+            font-family: 'Inter', sans-serif;
+            font-size: 0.6em;
+            font-weight: 200;
+            opacity: 0.4;
+        }
+
+        .nav-menu {
+            display: flex;
+            list-style: none;
+            gap: 0.15rem;
+        }
+
+        .nav-menu a {
+            color: rgba(255, 255, 255, 0.5);
+            text-decoration: none;
+            font-size: 0.85rem;
+            font-weight: 400;
+            letter-spacing: 0.2px;
+            transition: color 0.3s;
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            padding: 0.35rem 0.7rem;
+            display: block;
+        }
+
+        .nav-menu a:hover {
+            color: white;
+        }
+
+        .nav-toggle {
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 0.5rem;
+        }
+
+        .nav-toggle span {
+            display: block;
+            width: 18px;
+            height: 1.5px;
+            background: rgba(255, 255, 255, 0.7);
+            transition: transform 0.3s, opacity 0.3s;
+        }
+
+        .nav-toggle span + span {
+            margin-top: 4px;
+        }
+
+        .nav-container.nav-open .nav-toggle span:nth-child(1) {
+            transform: translateY(5.5px) rotate(45deg);
+        }
+
+        .nav-container.nav-open .nav-toggle span:nth-child(2) {
+            opacity: 0;
+        }
+
+        .nav-container.nav-open .nav-toggle span:nth-child(3) {
+            transform: translateY(-5.5px) rotate(-45deg);
+        }
+
+        @media (max-width: 660px) {
+            .navbar {
+                padding: 0.75rem 0.75rem;
+            }
+
+            .nav-container {
+                flex-wrap: wrap;
+                padding: 0.75rem 1rem;
+            }
+
+            .nav-toggle {
+                display: flex;
+            }
+
+            .nav-menu {
+                display: flex;
+                width: 100%;
+                flex-direction: column;
+                gap: 0;
+                padding-top: 0;
+                max-height: 0;
+                overflow: hidden;
+                transition: max-height 0.35s ease, padding-top 0.35s ease;
+            }
+
+            .nav-container.nav-open .nav-menu {
+                max-height: 300px;
+                padding-top: 0.75rem;
+            }
+
+            .nav-menu a {
+                font-size: 0.8rem;
+                padding: 0.5rem 0.5rem;
+            }
+        }
+
+        .page-content {
+            padding: 8rem 2rem 6rem;
+            max-width: 780px;
+            margin: 0 auto;
+        }
+
+        .page-label {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.72rem;
+            font-weight: 500;
+            letter-spacing: 0.8px;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.3);
+            margin-bottom: 1rem;
+        }
+
+        .page-content h1 {
+            font-size: 3rem;
+            font-weight: 400;
+            margin-bottom: 0.75rem;
+            letter-spacing: 0.5px;
+            font-style: normal;
+            line-height: 1.1;
+        }
+
+        .page-subtitle {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 1rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.55);
+            margin-bottom: 3.5rem;
+            line-height: 1.7;
+        }
+
+        .policy-section {
+            margin-bottom: 2.5rem;
+            padding-bottom: 2.5rem;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        }
+
+        .policy-section:last-of-type {
+            border-bottom: none;
+        }
+
+        .policy-section h2 {
+            font-size: 1.4rem;
+            font-weight: 400;
+            font-style: normal;
+            letter-spacing: 0.3px;
+            margin-bottom: 0.9rem;
+            color: white;
+        }
+
+        .policy-section p {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.95rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.6);
+            line-height: 1.75;
+            margin-bottom: 0.75rem;
+        }
+
+        .policy-section p:last-child {
+            margin-bottom: 0;
+        }
+
+        .policy-list {
+            list-style: none;
+            margin-top: 0.75rem;
+        }
+
+        .policy-list li {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.95rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.6);
+            line-height: 1.75;
+            padding: 0.35rem 0;
+            padding-left: 1.2rem;
+            position: relative;
+        }
+
+        .policy-list li::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0.85rem;
+            width: 4px;
+            height: 4px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.25);
+        }
+
+        .contact-link {
+            color: rgba(255, 255, 255, 0.75);
+            text-decoration: none;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+            transition: color 0.3s, border-color 0.3s;
+        }
+
+        .contact-link:hover {
+            color: white;
+            border-color: rgba(255, 255, 255, 0.5);
+        }
+
+        .effective-date {
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.78rem;
+            font-weight: 400;
+            color: rgba(255, 255, 255, 0.25);
+            margin-top: 3rem;
+            letter-spacing: 0.3px;
+        }
+
+        .footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            font-family: 'Inter', sans-serif;
+            font-style: normal;
+            font-size: 0.8rem;
+            font-weight: 300;
+            color: rgba(255, 255, 255, 0.3);
+        }
+
+        .footer-links {
+            display: flex;
+            gap: 1.5rem;
+        }
+
+        .footer-links a {
+            color: rgba(255, 255, 255, 0.3);
+            text-decoration: none;
+            transition: color 0.3s;
+        }
+
+        .footer-links a:hover {
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        @media (max-width: 768px) {
+            .page-content {
+                padding: 7rem 1.5rem 5rem;
+            }
+
+            .page-content h1 {
+                font-size: 2.2rem;
+            }
+
+            .footer {
+                flex-direction: column;
+                gap: 1rem;
+                text-align: center;
+            }
+        }
+
+        .fade-in {
+            opacity: 0;
+            transform: translateY(16px);
+            transition: opacity 0.5s ease, transform 0.5s ease;
+        }
+
+        .fade-in.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .fade-in-delay-1 { transition-delay: 0.1s; }
+        .fade-in-delay-2 { transition-delay: 0.2s; }
+        .fade-in-delay-3 { transition-delay: 0.3s; }
+    </style>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container" id="nav-container">
+            <a href="/" class="logo"><span class="logo-first">Alec </span>Jude Wilson</a>
+            <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <ul class="nav-menu" id="nav-menu">
+                <li><a href="/projects">Projects</a></li>
+                <li><a href="/photo.html">Photos</a></li>
+                <li><a href="/about.html">About</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <div class="page-content">
+        <p class="page-label fade-in">Legal</p>
+        <h1 class="fade-in fade-in-delay-1">Privacy Policy</h1>
+        <p class="page-subtitle fade-in fade-in-delay-2">A straightforward promise: your data is yours. We don't see it, store it, or touch it.</p>
+
+        <div class="policy-section fade-in fade-in-delay-3">
+            <h2>We collect no data</h2>
+            <p>Our apps do not collect, transmit, or store any personal information on our servers — because we don't have any. There are no accounts, no sign-ups, and no tracking of any kind.</p>
+            <ul class="policy-list">
+                <li>No account required to use any of our apps</li>
+                <li>No usage analytics or behavioral tracking</li>
+                <li>No personal information is ever sent to us</li>
+                <li>No advertising identifiers or third-party SDKs</li>
+            </ul>
+        </div>
+
+        <div class="policy-section fade-in">
+            <h2>Your device, your iCloud</h2>
+            <p>Any data you create in our apps — notes, entries, settings, or anything else — lives on your device or in your personal iCloud account if you have iCloud sync enabled. That storage is managed entirely by Apple and governed by <a href="https://www.apple.com/legal/privacy/" class="contact-link" target="_blank">Apple's Privacy Policy</a>.</p>
+            <p>We have no access to your iCloud data. We never will.</p>
+        </div>
+
+        <div class="policy-section fade-in">
+            <h2>No ads, no tracking</h2>
+            <p>We don't use advertising networks, third-party analytics tools, or any service that monitors how you use our apps. Your activity is never observed, profiled, shared, or sold.</p>
+        </div>
+
+        <div class="policy-section fade-in">
+            <h2>Children's privacy</h2>
+            <p>Because we collect no data at all, our apps are safe for users of any age. We have no mechanism to collect information from anyone, including children.</p>
+        </div>
+
+        <div class="policy-section fade-in">
+            <h2>Changes to this policy</h2>
+            <p>If we ever change how our apps handle data, we'll update this page and revise the effective date below. The current version always lives at <a href="/legal/privacy-policy" class="contact-link">judes.club/legal/privacy-policy</a>.</p>
+        </div>
+
+        <div class="policy-section fade-in">
+            <h2>Questions</h2>
+            <p>If you have any questions about this privacy policy, reach out at <a href="mailto:hi@judes.club" class="contact-link">hi@judes.club</a>.</p>
+        </div>
+
+        <p class="effective-date fade-in">Last updated: February 2026</p>
+    </div>
+
+    <footer class="footer">
+        <span>&copy; 2026 Alec Jude Wilson</span>
+        <div class="footer-links">
+            <a href="/">Home</a>
+            <a href="https://github.com/alechash" target="_blank">GitHub</a>
+            <a href="https://x.com/alechash" target="_blank">X</a>
+        </div>
+    </footer>
+
+    <script>
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+
+        document.getElementById('nav-toggle').addEventListener('click', function () {
+            document.getElementById('nav-container').classList.toggle('nav-open');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Added a new privacy policy page at `/legal/privacy-policy.html` that clearly communicates the app's data handling practices to users.

## Key Changes
- Created a comprehensive privacy policy page with the following sections:
  - Data collection practices (none)
  - Device and iCloud storage explanation
  - No ads or tracking commitment
  - Children's privacy assurance
  - Policy update procedures
  - Contact information for questions
- Implemented consistent styling with the existing site design using:
  - Dark theme with white text on #111 background
  - Instrument Serif and Inter font families
  - Responsive navigation bar with mobile hamburger menu
  - Fade-in animations for content sections
  - Mobile-responsive layout
- Included footer with copyright and social links matching site conventions

## Notable Implementation Details
- Uses Intersection Observer API for fade-in animations triggered on scroll
- Mobile-responsive navigation with collapsible menu for screens ≤660px
- Semantic HTML structure with proper heading hierarchy
- Accessible navigation toggle with ARIA labels
- Smooth scroll behavior and backdrop blur effects on navbar
- Last updated date set to February 2026

https://claude.ai/code/session_016dgtPG5jcrrzJ3pzx5ozWU