### PR TITLE
Rebrand judes.club as a "Founder of Belayer" site

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,29 +23,49 @@
 
 <!-- Verbuise — sticky language picker; translates every page into any language, live. -->
 <div class="vb-lang-picker" data-vb-skip>
-  <span class="vb-globe" aria-hidden="true">🌐</span>
+  <svg class="vb-globe" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="9.2"/><path d="M3 12h18"/><path d="M12 2.8c2.6 2.7 2.6 15.7 0 18.4M12 2.8c-2.6 2.7-2.6 15.7 0 18.4"/>
+  </svg>
   <select id="vb-lang" aria-label="Language"></select>
-  <a href="https://verbuise.com" target="_blank" rel="noopener" class="vb-powered">powered by&nbsp;Verbuise</a>
+  <a href="https://verbuise.com" target="_blank" rel="noopener" class="vb-powered">Verbuise</a>
 </div>
 
 <style>
   .vb-lang-picker {
-    position: fixed; bottom: 18px; right: 18px; z-index: 2147483000;
-    display: inline-flex; align-items: center; gap: .5rem;
-    background: rgba(20,20,22,.82); color: #fff; backdrop-filter: blur(8px);
-    border: 1px solid rgba(255,255,255,.18); border-radius: 999px;
-    padding: 7px 12px; font: 500 14px/1 system-ui, sans-serif;
-    box-shadow: 0 6px 24px rgba(0,0,0,.25);
+    position: fixed; bottom: 20px; right: 20px; z-index: 2147483000;
+    display: inline-flex; align-items: center; gap: .15rem;
+    background: var(--nav-bg); color: var(--text);
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--line); border-radius: 999px;
+    padding: 5px 6px 5px 12px; font: 500 13px/1 var(--sans);
+    box-shadow: var(--popover-shadow);
+    transition: border-color .25s var(--ease), transform .25s var(--ease);
   }
-  .vb-lang-picker .vb-globe { font-size: 15px; }
+  .vb-lang-picker:hover { border-color: var(--btn-hover-border); transform: translateY(-1px); }
+  .vb-lang-picker .vb-globe { color: var(--muted); opacity: .9; flex: none; }
   .vb-lang-picker select {
-    font: inherit; color: #fff; background: transparent; border: none; cursor: pointer; outline: none;
-    max-width: 150px;
+    appearance: none; -webkit-appearance: none; -moz-appearance: none;
+    font: inherit; color: var(--text); letter-spacing: .01em;
+    background: transparent; border: none; cursor: pointer; outline: none;
+    padding: 5px 24px 5px 8px; max-width: 150px; border-radius: 999px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2.6' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right 8px center; background-size: 10px;
+    transition: background-color .2s var(--ease);
   }
-  .vb-lang-picker select option { color: #111; }
-  .vb-lang-picker .vb-powered { font-size: 11px; opacity: .65; text-decoration: none; color: #fff; padding-left: 4px; border-left: 1px solid rgba(255,255,255,.2); }
-  .vb-lang-picker .vb-powered:hover { opacity: 1; }
-  @media (max-width: 480px) { .vb-lang-picker { bottom: 12px; right: 12px; padding: 6px 10px; } .vb-lang-picker .vb-powered { display: none; } }
+  .vb-lang-picker select:hover { background-color: var(--glass-2); }
+  .vb-lang-picker select:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .vb-lang-picker select option { color: #1a1813; background: #f6f5f1; }
+  .vb-lang-picker .vb-powered {
+    font-size: 10px; letter-spacing: .06em; text-transform: uppercase;
+    opacity: .6; text-decoration: none; color: var(--muted);
+    padding: 0 10px; margin-left: 2px; border-left: 1px solid var(--line);
+    transition: opacity .2s var(--ease), color .2s var(--ease);
+  }
+  .vb-lang-picker .vb-powered:hover { opacity: 1; color: var(--text); }
+  @media (max-width: 480px) {
+    .vb-lang-picker { bottom: 14px; right: 14px; }
+    .vb-lang-picker .vb-powered { display: none; }
+  }
 </style>
 
 <!-- Verbuise — this whole site translates into any language, live. -->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -6,7 +6,10 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links">
-      <li><button class="theme-toggle" type="button" aria-label="Switch to light mode" aria-pressed="false" title="Switch theme"></button></li>
+      <li><button class="theme-toggle" type="button" aria-label="Switch to light mode" aria-pressed="false" title="Switch theme">
+        <svg class="t-icon t-sun" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4.1"/><path d="M12 2.4v2.3M12 19.3v2.3M4.2 12H1.9M22.1 12h-2.3M5.7 5.7l1.6 1.6M16.7 16.7l1.6 1.6M18.3 5.7l-1.6 1.6M7.3 16.7l-1.6 1.6"/></svg>
+        <svg class="t-icon t-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+      </button></li>
       <li><a href="/writing/" class="{% if p contains '/writing' %}active{% endif %}">Writing</a></li>
       <li><a href="https://belayer.dev" target="_blank" rel="noopener">Belayer &nearr;</a></li>
       <li><a href="/#contact" class="nav-cta">Contact</a></li>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -267,34 +267,34 @@ h1, h2, h3, h4 {
 
 .theme-toggle {
   position: relative;
-  display: inline-flex;
-  align-items: center;
-  width: 2.65rem;
-  height: 1.45rem;
-  margin: 0 0.35rem 0 0.15rem;
+  display: inline-grid;
+  place-items: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  margin: 0 0.3rem 0 0.15rem;
   padding: 0;
   border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--glass-2);
+  border-radius: 50%;
+  background: var(--glass);
+  color: var(--muted);
   cursor: pointer;
   vertical-align: middle;
-  transition: background 0.25s var(--ease), border-color 0.25s var(--ease), box-shadow 0.25s var(--ease);
+  overflow: hidden;
+  transition: color 0.25s var(--ease), background 0.25s var(--ease), border-color 0.25s var(--ease);
 }
-.theme-toggle::before {
-  content: "";
-  position: absolute;
-  top: 0.21rem;
-  left: 0.22rem;
-  width: 1rem;
-  height: 1rem;
-  border-radius: 50%;
-  background: var(--text);
-  box-shadow: 0 1px 5px var(--line);
-  transition: transform 0.25s var(--ease), background 0.25s var(--ease);
-}
-.theme-toggle:hover { border-color: var(--btn-hover-border); box-shadow: 0 0 0 3px var(--glass); }
+.theme-toggle:hover { color: var(--text); background: var(--glass-2); border-color: var(--btn-hover-border); }
 .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
-:root[data-theme="light"] .theme-toggle::before { transform: translateX(1.18rem); }
+.theme-toggle .t-icon {
+  grid-area: 1 / 1;
+  transition: opacity 0.35s var(--ease), transform 0.45s var(--ease);
+}
+/* Dark mode shows the sun (tap to go light); light mode shows the moon. */
+.theme-toggle .t-sun  { opacity: 1; transform: rotate(0) scale(1); }
+.theme-toggle .t-moon { opacity: 0; transform: rotate(-80deg) scale(0.45); }
+.theme-toggle:hover .t-sun { transform: rotate(35deg) scale(1); }
+:root[data-theme="light"] .theme-toggle .t-sun  { opacity: 0; transform: rotate(80deg) scale(0.45); }
+:root[data-theme="light"] .theme-toggle .t-moon { opacity: 1; transform: rotate(0) scale(1); }
+:root[data-theme="light"] .theme-toggle:hover .t-moon { transform: rotate(-18deg) scale(1); }
 
 .nav-toggle {
   display: none;

--- a/index.html
+++ b/index.html
@@ -20,11 +20,6 @@ description: >-
       <a href="https://belayer.dev" class="btn btn-primary">Visit Belayer &nbsp;&rarr;</a>
       <a href="/writing/" class="btn">Read the writing</a>
     </div>
-    <div class="hero-meta reveal d4">
-      <div class="item"><span class="k">Role</span><span class="v">Founder, Belayer</span></div>
-      <div class="item"><span class="k">Based in</span><span class="v">New York, USA</span></div>
-      <div class="item"><span class="k">Focus</span><span class="v">Web, Mobile &amp; AI</span></div>
-    </div>
   </div>
   <span class="photo-credit">Manta, Ecuador</span>
 </header>
@@ -41,32 +36,11 @@ description: >-
     </div>
 
     {% if site.posts.size > 0 %}
-      {% assign featured = site.posts.first %}
-      {% assign fwords = featured.content | number_of_words %}
-      {% assign frt = fwords | divided_by: 200 | plus: 1 %}
-      <a href="{{ featured.url }}" class="feature-post reveal">
-        <div class="fp-body">
-          <span class="fp-tag">Latest</span>
-          <h3>{{ featured.title }}</h3>
-          <p class="fp-excerpt">{{ featured.description | default: featured.excerpt | strip_html | truncate: 180 }}</p>
-          <div class="fp-foot">
-            <span>{{ featured.date | date: "%B %-d, %Y" }}</span>
-            <span>&middot;</span>
-            <span>{{ frt }} min read</span>
-          </div>
-        </div>
-        <div class="fp-side">
-          <span class="fp-mark">&ldquo;</span>
-          <span class="fp-readtime">Read &rarr;</span>
-        </div>
-      </a>
-
-      {% if site.posts.size > 1 %}
-      <div class="post-list">
-        {% for post in site.posts offset:1 limit:4 %}
+      <div class="post-list reveal">
+        {% for post in site.posts limit:5 %}
           {% assign words = post.content | number_of_words %}
           {% assign rt = words | divided_by: 200 | plus: 1 %}
-          <a href="{{ post.url }}" class="post-row reveal">
+          <a href="{{ post.url }}" class="post-row">
             <span class="pr-date">{{ post.date | date: "%b %-d, %Y" }}</span>
             <span class="pr-title">{{ post.title }}
               <span class="pr-sub">{{ post.description | default: post.excerpt | strip_html | truncate: 110 }}</span>
@@ -75,7 +49,6 @@ description: >-
           </a>
         {% endfor %}
       </div>
-      {% endif %}
     {% else %}
       <p class="lead reveal">Writing is on the way &mdash; the first posts land shortly.</p>
     {% endif %}
@@ -90,16 +63,9 @@ description: >-
         <p class="eyebrow"><span class="num">02</span>About</p>
         <h2>A little about me</h2>
         <p>
-          I&rsquo;m a software engineer and founder based in New York. Most of my
-          work lives at the intersection of clean engineering and considered
-          design &mdash; web platforms, iOS apps, and AI-assisted tools that stay
-          calm and out of the way.
-        </p>
-        <p>
-          I run <strong>Belayer Development</strong>, my software &amp; AI
-          consultancy, helping growing companies plan, build, and ship products
-          they can trust. The writing here is where the thinking behind that work
-          lives &mdash; honest notes on engineering and craft.
+          I&rsquo;m a software engineer and founder in New York. I run
+          <strong>Belayer Development</strong>, my software &amp; AI consultancy,
+          and write here about the engineering and craft behind the work.
         </p>
       </div>
       <div class="contact-card reveal d1">


### PR DESCRIPTION
Reframes the personal site around the founder-of-Belayer positioning, with a simpler UI. The blog is kept; Projects and Photography are hidden (unlinked but left in the repo to move to the Belayer site later).

## Changes

**Positioning & content**
- Homepage hero is now founder-framed, with equal-weight links to belayer.dev and the writing.
- Nav and footer: Projects/Photography links replaced with a single Belayer link; Writing stays the primary section.
- Config: tagline → "Founder of Belayer", refreshed site description/SEO.

**Simpler homepage**
- Dropped the Projects + Photography side-grid and the photo lightbox/JS.
- Removed the hero meta row.
- Replaced the two-column featured-post card with a single clean recent-writing list.
- Tightened the about block to one paragraph.

**UI refinements**
- Language picker: now theme-aware (adapts to light/dark), refined SVG globe in place of the emoji, custom caret, subtle hover.
- Theme toggle: round icon button that animates between a sun (dark mode) and a moon (light mode), replacing the pill switch.

## Notes
- Projects and Photography pages remain in the repo, just unlinked from nav/footer/homepage — nothing deleted.
- The blog/writing is unchanged.
- Verified with a clean `jekyll build` (no errors). Not screenshotted — no headless browser in the build environment — so a quick visual check of the toggle animation and language picker on both themes is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011uJ1Sfno29ohQLH6vYaZ5r)_