### PR TITLE
Revert "Founder of Belayer" rebrand — restore original site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 # --- Site ---------------------------------------------------------------
 title: Alec Jude Wilson
-tagline: Founder of Belayer
+tagline: Software Engineer
 description: >-
-  Alec Jude Wilson is the founder of Belayer Development, a software & AI
-  consultancy in New York. Writing on engineering, building products, and craft.
+  Alec Jude Wilson is a software engineer in New York building web and mobile
+  software. Writing on engineering and craft, selected projects, and photography.
 url: "https://judes.club"
 baseurl: ""
 lang: en

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,8 +8,10 @@
       <nav class="footer-nav" aria-label="Footer">
         <a href="/">Home</a>
         <a href="/writing/">Writing</a>
-        <a href="https://belayer.dev" target="_blank" rel="noopener">Belayer</a>
+        <a href="/projects/">Projects</a>
+        <a href="/photo/">Photography</a>
         <a href="{{ site.social.github }}" target="_blank" rel="noopener">GitHub</a>
+        <a href="{{ site.social.instagram }}" target="_blank" rel="noopener">Instagram</a>
         <a href="{{ site.social.x }}" target="_blank" rel="noopener">X</a>
         <a href="/legal/">Legal</a>
       </nav>
@@ -23,49 +25,29 @@
 
 <!-- Verbuise — sticky language picker; translates every page into any language, live. -->
 <div class="vb-lang-picker" data-vb-skip>
-  <svg class="vb-globe" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="9.2"/><path d="M3 12h18"/><path d="M12 2.8c2.6 2.7 2.6 15.7 0 18.4M12 2.8c-2.6 2.7-2.6 15.7 0 18.4"/>
-  </svg>
+  <span class="vb-globe" aria-hidden="true">🌐</span>
   <select id="vb-lang" aria-label="Language"></select>
-  <a href="https://verbuise.com" target="_blank" rel="noopener" class="vb-powered">Verbuise</a>
+  <a href="https://verbuise.com" target="_blank" rel="noopener" class="vb-powered">powered by&nbsp;Verbuise</a>
 </div>
 
 <style>
   .vb-lang-picker {
-    position: fixed; bottom: 20px; right: 20px; z-index: 2147483000;
-    display: inline-flex; align-items: center; gap: .15rem;
-    background: var(--nav-bg); color: var(--text);
-    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
-    border: 1px solid var(--line); border-radius: 999px;
-    padding: 5px 6px 5px 12px; font: 500 13px/1 var(--sans);
-    box-shadow: var(--popover-shadow);
-    transition: border-color .25s var(--ease), transform .25s var(--ease);
+    position: fixed; bottom: 18px; right: 18px; z-index: 2147483000;
+    display: inline-flex; align-items: center; gap: .5rem;
+    background: rgba(20,20,22,.82); color: #fff; backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.18); border-radius: 999px;
+    padding: 7px 12px; font: 500 14px/1 system-ui, sans-serif;
+    box-shadow: 0 6px 24px rgba(0,0,0,.25);
   }
-  .vb-lang-picker:hover { border-color: var(--btn-hover-border); transform: translateY(-1px); }
-  .vb-lang-picker .vb-globe { color: var(--muted); opacity: .9; flex: none; }
+  .vb-lang-picker .vb-globe { font-size: 15px; }
   .vb-lang-picker select {
-    appearance: none; -webkit-appearance: none; -moz-appearance: none;
-    font: inherit; color: var(--text); letter-spacing: .01em;
-    background: transparent; border: none; cursor: pointer; outline: none;
-    padding: 5px 24px 5px 8px; max-width: 150px; border-radius: 999px;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2.6' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-    background-repeat: no-repeat; background-position: right 8px center; background-size: 10px;
-    transition: background-color .2s var(--ease);
+    font: inherit; color: #fff; background: transparent; border: none; cursor: pointer; outline: none;
+    max-width: 150px;
   }
-  .vb-lang-picker select:hover { background-color: var(--glass-2); }
-  .vb-lang-picker select:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-  .vb-lang-picker select option { color: #1a1813; background: #f6f5f1; }
-  .vb-lang-picker .vb-powered {
-    font-size: 10px; letter-spacing: .06em; text-transform: uppercase;
-    opacity: .6; text-decoration: none; color: var(--muted);
-    padding: 0 10px; margin-left: 2px; border-left: 1px solid var(--line);
-    transition: opacity .2s var(--ease), color .2s var(--ease);
-  }
-  .vb-lang-picker .vb-powered:hover { opacity: 1; color: var(--text); }
-  @media (max-width: 480px) {
-    .vb-lang-picker { bottom: 14px; right: 14px; }
-    .vb-lang-picker .vb-powered { display: none; }
-  }
+  .vb-lang-picker select option { color: #111; }
+  .vb-lang-picker .vb-powered { font-size: 11px; opacity: .65; text-decoration: none; color: #fff; padding-left: 4px; border-left: 1px solid rgba(255,255,255,.2); }
+  .vb-lang-picker .vb-powered:hover { opacity: 1; }
+  @media (max-width: 480px) { .vb-lang-picker { bottom: 12px; right: 12px; padding: 6px 10px; } .vb-lang-picker .vb-powered { display: none; } }
 </style>
 
 <!-- Verbuise — this whole site translates into any language, live. -->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -6,12 +6,10 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links">
-      <li><button class="theme-toggle" type="button" aria-label="Switch to light mode" aria-pressed="false" title="Switch theme">
-        <svg class="t-icon t-sun" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4.1"/><path d="M12 2.4v2.3M12 19.3v2.3M4.2 12H1.9M22.1 12h-2.3M5.7 5.7l1.6 1.6M16.7 16.7l1.6 1.6M18.3 5.7l-1.6 1.6M7.3 16.7l-1.6 1.6"/></svg>
-        <svg class="t-icon t-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
-      </button></li>
+      <li><button class="theme-toggle" type="button" aria-label="Switch to light mode" aria-pressed="false" title="Switch theme"></button></li>
       <li><a href="/writing/" class="{% if p contains '/writing' %}active{% endif %}">Writing</a></li>
-      <li><a href="https://belayer.dev" target="_blank" rel="noopener">Belayer &nearr;</a></li>
+      <li><a href="/projects/" class="{% if p contains '/projects' %}active{% endif %}">Projects</a></li>
+      <li><a href="/photo/" class="{% if p contains '/photo' %}active{% endif %}">Photography</a></li>
       <li><a href="/#contact" class="nav-cta">Contact</a></li>
     </ul>
   </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -267,34 +267,34 @@ h1, h2, h3, h4 {
 
 .theme-toggle {
   position: relative;
-  display: inline-grid;
-  place-items: center;
-  width: 2.2rem;
-  height: 2.2rem;
-  margin: 0 0.3rem 0 0.15rem;
+  display: inline-flex;
+  align-items: center;
+  width: 2.65rem;
+  height: 1.45rem;
+  margin: 0 0.35rem 0 0.15rem;
   padding: 0;
   border: 1px solid var(--line);
-  border-radius: 50%;
-  background: var(--glass);
-  color: var(--muted);
+  border-radius: 999px;
+  background: var(--glass-2);
   cursor: pointer;
   vertical-align: middle;
-  overflow: hidden;
-  transition: color 0.25s var(--ease), background 0.25s var(--ease), border-color 0.25s var(--ease);
+  transition: background 0.25s var(--ease), border-color 0.25s var(--ease), box-shadow 0.25s var(--ease);
 }
-.theme-toggle:hover { color: var(--text); background: var(--glass-2); border-color: var(--btn-hover-border); }
+.theme-toggle::before {
+  content: "";
+  position: absolute;
+  top: 0.21rem;
+  left: 0.22rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--text);
+  box-shadow: 0 1px 5px var(--line);
+  transition: transform 0.25s var(--ease), background 0.25s var(--ease);
+}
+.theme-toggle:hover { border-color: var(--btn-hover-border); box-shadow: 0 0 0 3px var(--glass); }
 .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
-.theme-toggle .t-icon {
-  grid-area: 1 / 1;
-  transition: opacity 0.35s var(--ease), transform 0.45s var(--ease);
-}
-/* Dark mode shows the sun (tap to go light); light mode shows the moon. */
-.theme-toggle .t-sun  { opacity: 1; transform: rotate(0) scale(1); }
-.theme-toggle .t-moon { opacity: 0; transform: rotate(-80deg) scale(0.45); }
-.theme-toggle:hover .t-sun { transform: rotate(35deg) scale(1); }
-:root[data-theme="light"] .theme-toggle .t-sun  { opacity: 0; transform: rotate(80deg) scale(0.45); }
-:root[data-theme="light"] .theme-toggle .t-moon { opacity: 1; transform: rotate(0) scale(1); }
-:root[data-theme="light"] .theme-toggle:hover .t-moon { transform: rotate(-18deg) scale(1); }
+:root[data-theme="light"] .theme-toggle::before { transform: translateX(1.18rem); }
 
 .nav-toggle {
   display: none;

--- a/index.html
+++ b/index.html
@@ -1,26 +1,32 @@
 ---
 layout: default
 description: >-
-  Alec Jude Wilson is the founder of Belayer Development, a software & AI
-  consultancy. He writes here about engineering, building products, and craft.
+  Alec Jude Wilson is a software engineer in New York. I build web and mobile
+  applications, write about engineering, and photograph the world.
 ---
 
 <!-- ===================== HERO ===================== -->
 <header class="hero">
   <div class="hero-bg" style="background-image:url('/bg.jpeg')"></div>
   <div class="hero-inner wrap">
-    <p class="eyebrow reveal">Founder &mdash; Belayer Development</p>
-    <h1 class="reveal d1">I&rsquo;m Alec. I build software companies, and write about <span class="em">the craft of building.</span></h1>
+    <p class="eyebrow reveal">Software Engineer &mdash; New York</p>
+    <h1 class="reveal d1">I build software, and write about <span class="em">the craft of building it.</span></h1>
     <p class="hero-sub reveal d2">
-      I founded <strong>Belayer Development</strong>, a software &amp; AI
-      consultancy that helps growing companies plan, build, and ship durable
-      digital products. This is where I keep my writing on the work behind it.
+      I&rsquo;m Alec. I design and ship web and mobile applications, run a small
+      software &amp; AI consultancy, and write here about what I learn building
+      real products.
     </p>
     <div class="hero-actions reveal d3">
-      <a href="https://belayer.dev" class="btn btn-primary">Visit Belayer &nbsp;&rarr;</a>
-      <a href="/writing/" class="btn">Read the writing</a>
+      <a href="/writing/" class="btn btn-primary">Read the writing &nbsp;&rarr;</a>
+      <a href="/projects/" class="btn">See the projects</a>
+    </div>
+    <div class="hero-meta reveal d4">
+      <div class="item"><span class="k">Location</span><span class="v">New York, USA</span></div>
+      <div class="item"><span class="k">Focus</span><span class="v">Web, Mobile &amp; AI</span></div>
+      <div class="item"><span class="k">Consultancy</span><span class="v">Belayer Development</span></div>
     </div>
   </div>
+  <div class="scroll-cue"><span>Scroll</span><span class="bar"></span></div>
   <span class="photo-credit">Manta, Ecuador</span>
 </header>
 
@@ -36,11 +42,32 @@ description: >-
     </div>
 
     {% if site.posts.size > 0 %}
-      <div class="post-list reveal">
-        {% for post in site.posts limit:5 %}
+      {% assign featured = site.posts.first %}
+      {% assign fwords = featured.content | number_of_words %}
+      {% assign frt = fwords | divided_by: 200 | plus: 1 %}
+      <a href="{{ featured.url }}" class="feature-post reveal">
+        <div class="fp-body">
+          <span class="fp-tag">Latest</span>
+          <h3>{{ featured.title }}</h3>
+          <p class="fp-excerpt">{{ featured.description | default: featured.excerpt | strip_html | truncate: 180 }}</p>
+          <div class="fp-foot">
+            <span>{{ featured.date | date: "%B %-d, %Y" }}</span>
+            <span>&middot;</span>
+            <span>{{ frt }} min read</span>
+          </div>
+        </div>
+        <div class="fp-side">
+          <span class="fp-mark">&ldquo;</span>
+          <span class="fp-readtime">Read &rarr;</span>
+        </div>
+      </a>
+
+      {% if site.posts.size > 1 %}
+      <div class="post-list">
+        {% for post in site.posts offset:1 limit:3 %}
           {% assign words = post.content | number_of_words %}
           {% assign rt = words | divided_by: 200 | plus: 1 %}
-          <a href="{{ post.url }}" class="post-row">
+          <a href="{{ post.url }}" class="post-row reveal">
             <span class="pr-date">{{ post.date | date: "%b %-d, %Y" }}</span>
             <span class="pr-title">{{ post.title }}
               <span class="pr-sub">{{ post.description | default: post.excerpt | strip_html | truncate: 110 }}</span>
@@ -49,9 +76,71 @@ description: >-
           </a>
         {% endfor %}
       </div>
+      {% endif %}
     {% else %}
       <p class="lead reveal">Writing is on the way &mdash; the first posts land shortly.</p>
     {% endif %}
+  </div>
+</section>
+
+<!-- ===================== PROJECTS + PHOTOGRAPHY (side pieces) ===================== -->
+<section class="section">
+  <div class="wrap">
+    <div class="side-grid">
+
+      <!-- Projects -->
+      <div class="side-card reveal">
+        <div class="sc-head">
+          <div>
+            <p class="eyebrow"><span class="num">02</span>Selected work</p>
+            <h3>Projects</h3>
+          </div>
+          <a href="/projects/" class="arrow-link">All <span class="ar">&rarr;</span></a>
+        </div>
+        <div class="mini-list">
+          {% assign home_projects = site.projects | sort: "order" %}
+          {% for project in home_projects limit:4 %}
+            <a href="{{ project.url }}" class="mini-row">
+              {% if project.cover %}<img src="{{ project.cover }}" alt="{{ project.title }}" class="mr-thumb" loading="lazy">{% endif %}
+              <span class="mr-text">
+                <span class="mr-title">{{ project.title }}</span>
+                <span class="mr-desc">{{ project.tagline }}</span>
+              </span>
+              <span class="mr-meta">{{ project.kind }}</span>
+            </a>
+          {% endfor %}
+        </div>
+        <div class="sc-links">
+          <a href="{{ site.social.github }}" target="_blank" rel="noopener">GitHub &nearr;</a>
+          <a href="/projects/">Full project list &rarr;</a>
+        </div>
+      </div>
+
+      <!-- Photography -->
+      <div class="side-card reveal d1">
+        <div class="sc-head">
+          <div>
+            <p class="eyebrow"><span class="num">03</span>Off-screen</p>
+            <h3>Photography</h3>
+          </div>
+          <a href="/photo/" class="arrow-link">Gallery <span class="ar">&rarr;</span></a>
+        </div>
+        <div class="photo-strip" id="home-photos">
+          <div class="photo-cell"></div><div class="photo-cell"></div><div class="photo-cell"></div>
+          <div class="photo-cell"></div><div class="photo-cell"></div><div class="photo-cell"></div>
+        </div>
+        <p class="lead" style="font-size:0.9rem;margin-bottom:0.2rem">
+          Travel &amp; street photography. The full gallery carries live view,
+          like, and download counts straight from Unsplash.
+        </p>
+        <div class="sc-links">
+          <a href="/photo/">Open the gallery &rarr;</a>
+          <a href="{{ site.social.instagram }}" target="_blank" rel="noopener">Instagram &nearr;</a>
+          <a href="https://judes.darkroom.com" target="_blank" rel="noopener">Prints &nearr;</a>
+        </div>
+      </div>
+
+    </div>
   </div>
 </section>
 
@@ -60,12 +149,23 @@ description: >-
   <div class="wrap">
     <div class="closer">
       <div class="about-text reveal">
-        <p class="eyebrow"><span class="num">02</span>About</p>
+        <p class="eyebrow"><span class="num">04</span>About</p>
         <h2>A little about me</h2>
         <p>
-          I&rsquo;m a software engineer and founder in New York. I run
-          <strong>Belayer Development</strong>, my software &amp; AI consultancy,
-          and write here about the engineering and craft behind the work.
+          I&rsquo;m a software engineer based in New York. Most of my work lives at
+          the intersection of clean engineering and considered design &mdash; web
+          platforms, iOS apps, and AI-assisted tools that try to stay calm and out
+          of the way.
+        </p>
+        <p>
+          Through <strong>Belayer Development</strong>, my software &amp; AI
+          consultancy, I help growing companies plan, build, and ship digital
+          products. On the side I&rsquo;ve put a few of my own apps on the App
+          Store, and I shoot photography wherever I travel.
+        </p>
+        <p>
+          This site is where I keep all of it &mdash; the writing first, then the
+          work behind it.
         </p>
       </div>
       <div class="contact-card reveal d1">
@@ -74,11 +174,102 @@ description: >-
         <p>Have a project, a question, or just want to say hello? The fastest way to reach me is email.</p>
         <a href="mailto:hi@judes.club" class="contact-email">hi@judes.club</a>
         <div class="contact-socials">
-          <a href="https://belayer.dev" target="_blank" rel="noopener">Belayer</a>
           <a href="{{ site.social.github }}" target="_blank" rel="noopener">GitHub</a>
           <a href="{{ site.social.x }}" target="_blank" rel="noopener">X / Twitter</a>
+          <a href="{{ site.social.instagram }}" target="_blank" rel="noopener">Instagram</a>
         </div>
       </div>
     </div>
   </div>
 </section>
+
+<!-- Lightbox -->
+<div class="lightbox" id="lightbox" aria-hidden="true">
+  <div class="lightbox-inner">
+    <img id="lb-img" src="" alt="Photograph">
+    <div class="lightbox-row">
+      <button class="lightbox-arrow" id="lb-prev" aria-label="Previous">&#8249;</button>
+      <div class="lightbox-actions">
+        <a id="lb-download" class="btn" href="" download>Download</a>
+        <a class="btn" href="/photo/">View gallery</a>
+        <button class="btn" id="lb-close">Close</button>
+      </div>
+      <button class="lightbox-arrow" id="lb-next" aria-label="Next">&#8250;</button>
+    </div>
+    <p class="lightbox-attr" id="lb-attr"></p>
+  </div>
+</div>
+
+<script>
+(function () {
+  var API = "{{ site.photos_api }}";
+  var grid = document.getElementById('home-photos');
+  if (!grid) return;
+
+  var lb = document.getElementById('lightbox');
+  var lbImg = document.getElementById('lb-img');
+  var lbDl = document.getElementById('lb-download');
+  var lbAttr = document.getElementById('lb-attr');
+  var photos = [];
+  var idx = 0;
+
+  function showLightbox(i) {
+    idx = (i + photos.length) % photos.length;
+    var p = photos[idx];
+    lbImg.src = p.url_regular;
+    lbImg.alt = p.alt_description || 'Photograph';
+    lbDl.href = p.url_regular;
+    lbAttr.innerHTML = 'Photo by <a href="' + p.user_profile + '" target="_blank" rel="noopener">' + p.user_name +
+      '</a> on <a href="' + p.attribution_url + '" target="_blank" rel="noopener">Unsplash</a>';
+    lb.style.display = 'flex';
+    requestAnimationFrame(function () { requestAnimationFrame(function () {
+      lb.classList.add('active'); document.body.style.overflow = 'hidden';
+    }); });
+  }
+  function closeLightbox() {
+    lb.classList.add('closing'); lb.classList.remove('active');
+    setTimeout(function () {
+      lb.classList.remove('closing'); lb.style.display = 'none';
+      document.body.style.overflow = ''; lbImg.src = '';
+    }, 380);
+  }
+  document.getElementById('lb-close').addEventListener('click', closeLightbox);
+  document.getElementById('lb-prev').addEventListener('click', function () { showLightbox(idx - 1); });
+  document.getElementById('lb-next').addEventListener('click', function () { showLightbox(idx + 1); });
+  lb.addEventListener('click', function (e) { if (e.target === lb) closeLightbox(); });
+  document.addEventListener('keydown', function (e) {
+    if (!lb.classList.contains('active')) return;
+    if (e.key === 'Escape') closeLightbox();
+    if (e.key === 'ArrowRight') showLightbox(idx + 1);
+    if (e.key === 'ArrowLeft') showLightbox(idx - 1);
+  });
+
+  function render() {
+    grid.innerHTML = '';
+    photos.forEach(function (p, i) {
+      var cell = document.createElement('div');
+      cell.className = 'photo-cell';
+      cell.innerHTML =
+        '<button type="button" aria-label="Open photograph">' +
+          '<img src="' + (p.url_small || p.url_regular) + '" alt="' +
+            (p.alt_description || 'Photograph') + '" loading="lazy" decoding="async">' +
+        '</button>';
+      cell.querySelector('button').addEventListener('click', function () { showLightbox(i); });
+      grid.appendChild(cell);
+    });
+  }
+
+  fetch(API + '/photos?page=1&limit=50')
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      var all = data.results || [];
+      for (var i = all.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        var t = all[i]; all[i] = all[j]; all[j] = t;
+      }
+      photos = all.slice(0, 6);
+      if (photos.length) render();
+    })
+    .catch(function (e) { console.error(e); });
+})();
+</script>


### PR DESCRIPTION
Reverts the founder-of-Belayer rebrand that was merged into `main` via #21 and #22, restoring the original software-engineer site.

## What this restores
- `index.html` — original homepage with the featured-post card, the Projects + Photography side-grid, and the full about/contact section.
- `_includes/nav.html` / `_includes/footer.html` — original nav and footer (Projects, Photography, Instagram links back).
- `_config.yml` — tagline back to "Software Engineer" and the original description/SEO.
- `assets/css/style.css` — original theme toggle (pill switch) and language-picker styling.

## Verification
The branch tree is byte-identical to the pre-rebrand commit `1aa70db` (`git diff --quiet 1aa70db HEAD` passes), and `jekyll build` completes cleanly.

No force-push to `main` — this lands as a normal revert commit via this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011uJ1Sfno29ohQLH6vYaZ5r)_